### PR TITLE
Update krel to v0.16.3

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,7 +71,7 @@ dependencies:
         match: SHFMT_VERSION
 
   - name: krel
-    version: v0.16.2
+    version: v0.16.3
     refPaths:
       - path: scripts/helpers
         match: KREL_VERSION

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -27,7 +27,7 @@ install_osc() {
 }
 
 install_krel() {
-    KREL_VERSION=v0.16.2
+    KREL_VERSION=v0.16.3
     BINARY=krel
     curl_retry https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes/release/$KREL_VERSION/$BINARY-amd64-linux -o $BINARY
     chmod +x $BINARY

--- a/scripts/obs
+++ b/scripts/obs
@@ -32,7 +32,6 @@ obs_stage() {
         --version "$VERSION" \
         --architectures amd64,arm64,ppc64le \
         --submit=false \
-        --wait \
         --nomock
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
`krel obs stage` now waits per default, means we can avoid the additional flag.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
