### PR TITLE
Use registries.conf.d instead of main registries.conf

### DIFF
--- a/templates/latest/cri-o/cri-o.spec
+++ b/templates/latest/cri-o/cri-o.spec
@@ -64,8 +64,10 @@ install -D -m 644 -t %{buildroot}%{_datadir}/zsh/site-functions %{archive_root}/
 
 # Configurations
 install -dp %{buildroot}%{_sysconfdir}/containers
+install -dp %{buildroot}%{_sysconfdir}/containers/registries.conf.d
 install -p -m 644 %{archive_root}/contrib/policy.json %{buildroot}%{_sysconfdir}/containers/policy.json
-install -p -m 644 %{archive_root}/contrib/registries.conf %{buildroot}%{_sysconfdir}/containers/registries.conf
+echo 'unqualified-search-registries = ["docker.io", "quay.io"]' > %{archive_root}/contrib/registries-v2.conf
+install -p -m 644 %{archive_root}/contrib/registries-v2.conf %{buildroot}%{_sysconfdir}/containers/registries.conf.d/crio.conf
 install -p -m 644 %{archive_root}/etc/crictl.yaml %{buildroot}%{_sysconfdir}/crictl.yaml
 
 install -dp %{buildroot}%{_sysconfdir}/crio/crio.conf.d
@@ -118,8 +120,9 @@ install -D -m 644 -t %{buildroot}%{_mandir}/man8 %{archive_root}/man/crio.8
 
 # Configurations
 %dir %{_sysconfdir}/containers
+%dir %{_sysconfdir}/containers/registries.conf.d
 %config(noreplace) %{_sysconfdir}/containers/policy.json
-%config(noreplace) %{_sysconfdir}/containers/registries.conf
+%config(noreplace) %{_sysconfdir}/containers/registries.conf.d/crio.conf
 %config(noreplace) %{_sysconfdir}/crictl.yaml
 %dir %{_sysconfdir}/cni
 %dir %{_sysconfdir}/cni/net.d


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows compatibility with the `golang-github-containers-image` package which writes `/etc/containers/registries.conf`. We now fallback to a CRI-O specific drop-in.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Follow-up on https://github.com/cri-o/packaging/issues/3
#### Special notes for your reviewer:
Ref https://github.com/cri-o/packaging/issues/3#issuecomment-1759713675

PTAL @afbjorklund
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched to registries.conf.d drop-in instead of main registries.conf to make the packages compatible with `golang-github-containers-image`.
```
