### PR TITLE
Make the two Vagrantfiles a little more similar

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,23 +117,13 @@ EOF
 #### Install package dependencies from the official repositories
 
 ```bash
-dnf install -y \
-    conntrack \
-    container-selinux \
-    ebtables \
-    ethtool \
-    iptables \
-    socat
+dnf install -y container-selinux
 ```
 
-#### Install the packages from the added repositories
+#### Install the packages
 
 ```bash
-dnf install -y --repo cri-o --repo kubernetes \
-    cri-o \
-    kubeadm \
-    kubectl \
-    kubelet
+dnf install -y cri-o kubelet kubeadm kubectl
 ```
 
 #### Start CRI-O

--- a/test/deb/Vagrantfile
+++ b/test/deb/Vagrantfile
@@ -1,6 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# Vagrant box for testing
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/ubuntu2204"
   memory = 6144
@@ -33,12 +34,13 @@ Vagrant.configure("2") do |config|
       echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
       apt-get update
 
-      # Install dependencies
       apt-get install -y cri-o kubelet kubeadm kubectl
       systemctl start crio
 
-      # Cluster setup
+      # Disable swap
       swapoff -a
+
+      # Cluster setup
       modprobe br_netfilter
       sysctl -w net.ipv4.ip_forward=1
       kubeadm init

--- a/test/rpm/Vagrantfile
+++ b/test/rpm/Vagrantfile
@@ -17,6 +17,8 @@ Vagrant.configure("2") do |config|
     v.cpus = cpus
   end
 
+  config.vm.synced_folder ".", "/vagrant"
+
   config.vm.provision "test", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
       set -euxo pipefail
@@ -45,20 +47,9 @@ gpgkey=https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repo
 EOF
 
       # Official package dependencies
-      dnf install -y \
-        conntrack \
-        container-selinux \
-        ebtables \
-        ethtool \
-        iptables \
-        socat
+      dnf install -y container-selinux
 
-      # From the added repos
-      dnf install -y --repo cri-o --repo kubernetes \
-        cri-o \
-        kubeadm \
-        kubectl \
-        kubelet
+      dnf install -y cri-o kubelet kubeadm kubectl
       systemctl start crio
 
       # Disable swap


### PR DESCRIPTION
Don't explicitly list the dependencies and repositories, but let the package manager sort it out. Only the wanted.

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Improve vagrant

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```

-----

Here is `dnf`, sorting out the dependencies:

```
[   62.655610] cloud-init[973]: + dnf install -y cri-o kubelet kubeadm kubectl
[   68.056763] cloud-init[973]: CRI-O                                           422  B/s | 2.1 kB     00:05
[   74.584228] cloud-init[973]: Kubernetes                                      1.7 kB/s | 9.9 kB     00:05
[   75.653594] cloud-init[973]: Dependencies resolved.
[   75.668175] cloud-init[973]: ================================================================================
[   75.668302] cloud-init[973]:  Package                      Arch    Version                 Repository   Size
[   75.668451] cloud-init[973]: ================================================================================
[   75.668736] cloud-init[973]: Installing:
[   75.668874] cloud-init[973]:  cri-o                        x86_64  1.29.0~dev-150500.81.1  cri-o        14 M
[   75.669027] cloud-init[973]:  kubeadm                      x86_64  1.28.2-150500.1.1       kubernetes  9.9 M
[   75.669324] cloud-init[973]:  kubectl                      x86_64  1.28.2-150500.1.1       kubernetes   10 M
[   75.669456] cloud-init[973]:  kubelet                      x86_64  1.28.2-150500.1.1       kubernetes   19 M
[   75.669758] cloud-init[973]: Installing dependencies:
[   75.669896] cloud-init[973]:  conntrack-tools              x86_64  1.4.7-1.fc38            updates     228 k
[   75.670045] cloud-init[973]:  containernetworking-plugins  x86_64  1.3.0-2.fc38            updates     8.8 M
[   75.670186] cloud-init[973]:  cri-tools                    x86_64  1.28.0-150500.1.1       kubernetes  8.1 M
[   75.670328] cloud-init[973]:  ebtables-legacy              x86_64  2.0.11-13.fc38          fedora       97 k
[   75.670476] cloud-init[973]:  ethtool                      x86_64  2:6.5-1.fc38            updates     244 k
[   75.670776] cloud-init[973]:  libnetfilter_cthelper        x86_64  1.0.0-23.fc38           fedora       22 k
[   75.670914] cloud-init[973]:  libnetfilter_cttimeout       x86_64  1.0.0-21.fc38           fedora       23 k
[   75.671048] cloud-init[973]:  libnetfilter_queue           x86_64  1.0.5-4.fc38            fedora       28 k
[   75.671193] cloud-init[973]:  socat                        x86_64  1.7.4.4-2.fc38          fedora      314 k
[   75.671335] cloud-init[973]: Transaction Summary
[   75.671486] cloud-init[973]: ================================================================================
[   75.671800] cloud-init[973]: Install  13 Packages
[   75.672100] cloud-init[973]: Total download size: 71 M
[   75.672373] cloud-init[973]: Installed size: 358 M
```

Only the `container-selinux`is needed.

Note that we have a duplicate between the "containernetworking-plugins" and "kubernetes-cni" packages.
(it picked the wrong package, due to the "recommends" working differently between dpkg and rpm, I guess)

`Requires: kubernetes-cni or containernetworking-plugins`
`Recommends: kubernetes-cni`


EDIT: scripts were duplicated in README