### PR TITLE
Remove dependency on containernetworking-plugins

### DIFF
--- a/templates/latest/cri-o/cri-o.spec
+++ b/templates/latest/cri-o/cri-o.spec
@@ -19,7 +19,7 @@ BuildRequires: systemd-deb-macros
 # The _unitdir macro does not exist on debbuild
 %define _unitdir %{_prefix}/lib/systemd/system
 Replaces: conmon, crun, golang-github-containers-common
-Requires: kubernetes-cni or containernetworking-plugins
+Recommends: kubernetes-cni
 %else
 BuildRequires: systemd-rpm-macros
 Conflicts: conmon, crun, containers-common

--- a/test/rpm/Dockerfile
+++ b/test/rpm/Dockerfile
@@ -12,7 +12,7 @@ gpgkey=https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repo
 " > /etc/yum.repos.d/cri-o.repo
 
 RUN dnf install -y \
-    containernetworking-plugins \
+    systemd \
     iptables
 
 RUN dnf install -y --repo cri-o cri-o


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind cleanup

#### What this PR does / why we need it:

Removes unused dependency on "containernetworking-plugins":

`/usr/lib/cni`

Convert the (mandatory) requires "kubernetes-cni" into recommends:

`/opt/cni/bin`

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

None

#### Special notes for your reviewer:

The ubuntu packages were quite old anyway, so did not match the requirement:

https://packages.ubuntu.com/containernetworking-plugins

The kubelet for 1.28 requires CNI 1.2, and those packages only featured 1.1.1

Let the kubernetes repo deal with it, and leave it "optional"

#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
