### PR TITLE
Give reconciliation more time

### DIFF
--- a/scripts/reconcile
+++ b/scripts/reconcile
@@ -14,6 +14,9 @@ setup_osc() {
 submit_workflow() {
     echo "Running GitHub OBS workflow for revision: $1"
     gh workflow run obs -F revision="$1"
+    echo "Giving the workflow a bit time before scheduling the next one," \
+        "otherwise we risk upload races to the Google Cloud Bucket."
+    sleep 300
 }
 
 install_osc


### PR DESCRIPTION



#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The CRI-O `main` branch and `release-1.29` get synchronized and may use the same commit. Means if we publish the signed static binary bundle in the same time via GitHub actions, we risk to upload wrong signatures to the corresponding artifacts. We avoid this now by giving the jobs a bit more time in-between.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
