### PR TITLE
Reuse environment vars and wait for GitHub actions to avoid races

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -29,8 +29,39 @@ env:
   OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
 
 jobs:
+  vars:
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    outputs:
+      archive_path: ${{ steps.step.outputs.ARCHIVE_PATH }}
+      commit: ${{ steps.step.outputs.COMMIT }}
+      git_root: ${{ steps.step.outputs.GIT_ROOT }}
+      project: ${{ steps.step.outputs.PROJECT }}
+      project_type: ${{ steps.step.outputs.PROJECT_TYPE }}
+      project_version: ${{ steps.step.outputs.PROJECT_VERSION }}
+      version: ${{ steps.step.outputs.VERSION }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: step
+        run: |
+          source scripts/vars
+          echo "ARCHIVE_PATH=$ARCHIVE_PATH" >> "$GITHUB_OUTPUT"
+          echo "COMMIT=$COMMIT" >> "$GITHUB_OUTPUT"
+          echo "GIT_ROOT=$GIT_ROOT" >> "$GITHUB_OUTPUT"
+          echo "PROJECT=$PROJECT" >> "$GITHUB_OUTPUT"
+          echo "PROJECT_TYPE=$PROJECT_TYPE" >> "$GITHUB_OUTPUT"
+          echo "PROJECT_VERSION=$PROJECT_VERSION" >> "$GITHUB_OUTPUT"
+          echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - run: scripts/github-job-wait
+        env:
+          COMMIT: ${{ steps.step.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
+      - name: COMMIT=${{ steps.step.outputs.commit }}
+        run: true
+
   bundles:
     runs-on: ubuntu-latest
+    needs: vars
     strategy:
       matrix:
         arch:
@@ -45,6 +76,13 @@ jobs:
         if: ${{ inputs.skip-bundles == false }}
         env:
           ARCH: ${{ matrix.arch }}
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}
       - uses: actions/upload-artifact@v3
         if: ${{ inputs.skip-bundles == false }}
         with:
@@ -54,7 +92,9 @@ jobs:
   bundle-test:
     name: bundle / test / ${{ inputs.revision || 'main' }} / amd64
     runs-on: ubuntu-latest
-    needs: bundles
+    needs:
+      - vars
+      - bundles
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v3
@@ -64,6 +104,14 @@ jobs:
           path: build/bundle
       - run: sudo -E scripts/bundle/test
         if: ${{ inputs.skip-bundles == false }}
+        env:
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}
 
   bundles-publish:
     name: bundles / publish / ${{ inputs.revision || 'main' }}
@@ -115,16 +163,28 @@ jobs:
     runs-on: ubuntu-latest
     name: stage / ${{ inputs.revision || 'main' }}
     timeout-minutes: 240
-    needs: bundles-publish
+    needs:
+      - vars
+      - bundles-publish
     steps:
       - uses: actions/checkout@v4
       - run: scripts/obs
         if: ${{ inputs.skip-stage == false && github.event_name != 'pull_request' }}
+        env:
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}
 
   test-kubernetes:
     runs-on: macos-12
     timeout-minutes: 120
-    needs: stage
+    needs:
+      - vars
+      - stage
     strategy:
       matrix:
         type:
@@ -142,11 +202,20 @@ jobs:
         if: ${{ inputs.skip-tests == false }}
         env:
           TYPE: ${{ matrix.type }}
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}
 
   test-architectures:
     runs-on: ubuntu-latest
     timeout-minutes: 120
-    needs: stage
+    needs:
+      - vars
+      - stage
     strategy:
       matrix:
         image:
@@ -182,11 +251,19 @@ jobs:
           IMAGE: ${{ matrix.image }}
           ARCH: ${{ matrix.arch }}
           TYPE: ${{ matrix.type }}
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}
 
   release:
     runs-on: ubuntu-latest
     name: release / ${{ inputs.revision || 'main' }}
     needs:
+      - vars
       - test-kubernetes
       - test-architectures
     steps:
@@ -195,3 +272,10 @@ jobs:
         if: ${{ inputs.skip-release == false && github.event_name != 'pull_request' }}
         env:
           RUN_RELEASE: 1
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          GIT_ROOT: ${{ needs.vars.outputs.git_root }}
+          PROJECT: ${{ needs.vars.outputs.project }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          PROJECT_VERSION: ${{ needs.vars.outputs.project_version }}
+          VERSION: ${{ needs.vars.outputs.version }}

--- a/scripts/bundle/build
+++ b/scripts/bundle/build
@@ -13,18 +13,7 @@ ARCH_ARM64=arm64
 ARCH_PPC64LE=ppc64le
 ARCH=${ARCH:-$ARCH_AMD64}
 
-if [[ $ARCH == "" ]]; then
-    echo "ARCH is not set"
-    exit 1
-fi
-
-REV_ID=$COMMIT
-if [[ $COMMIT == "" ]]; then
-    REV_ID=$REVISION
-    COMMIT=$(curl_retry https://api.github.com/repos/cri-o/cri-o/tags | jq -r '.[] | select(.name == "'"$REVISION"'") | .commit.sha')
-fi
-
-ARCHIVE="cri-o.$ARCH.$REV_ID.tar.gz"
+ARCHIVE="cri-o.$ARCH.$COMMIT.tar.gz"
 ARCHIVE_SHA256SUM="$ARCHIVE.sha256sum"
 
 mkdir -p "$ARCHIVE_PATH"

--- a/scripts/github-job-wait
+++ b/scripts/github-job-wait
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+COMMIT=${COMMIT:-}
+if [[ "$COMMIT" == "" ]]; then
+    echo "No commit provided"
+    exit 1
+fi
+
+echo "Checking if job with same commit $COMMIT is already running"
+
+for ID in $(gh run list -s in_progress -w obs --json databaseId -q '.[] | .databaseId'); do
+    RUNNING_COMMIT=$(gh run view "$ID" --json jobs \
+        -q '.jobs[] | select(.name == "vars") | .steps[] | select(.name | startswith("COMMIT")) | .name' |
+        grep -oEe "[0-9a-f]{40}" || true)
+
+    if [[ "$RUNNING_COMMIT" == "$COMMIT" ]]; then
+        echo "Job for commit '$COMMIT' is already running, waiting for it to complete"
+        gh run watch "$ID"
+    fi
+done

--- a/scripts/obs
+++ b/scripts/obs
@@ -16,8 +16,8 @@ RUN_RELEASE=${RUN_RELEASE:-0}
 export OBS_USERNAME=cri-o-release-bot
 
 obs_stage() {
-    if [[ "$COMMIT" != "" ]]; then
-        # Patch the package metadata to download the latest commit
+    # Patch the package metadata to download the latest commit for non tags
+    if ! [[ "$REVISION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         sed -i 's;gs://cri-o/artifacts/cri-o.{{ .Architecture }}.v{{ .PackageVersion }}.tar.gz;gs://cri-o/artifacts/cri-o.{{ .Architecture }}.'"$COMMIT"'.tar.gz;g' "$TEMPLATE_DIR/metadata.yaml"
     fi
     echo "Staging https://build.opensuse.org/package/show/$PROJECT/$PACKAGE"

--- a/scripts/vars
+++ b/scripts/vars
@@ -3,6 +3,12 @@ set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 
+GIT_ROOT=${GIT_ROOT:-}
+if [[ $GIT_ROOT != "" ]]; then
+    echo "Vars are already set, will not export them again"
+    return
+fi
+
 GIT_ROOT=$(git rev-parse --show-toplevel)
 ARCHIVE_PATH="$GIT_ROOT/build/bundle"
 PROJECT_ROOT=isv:kubernetes:addons:cri-o
@@ -11,7 +17,7 @@ REVISION=${REVISION:-$CRIO_MAIN_BRANCH}
 
 # Change the project based on the provided revision
 if [[ "$REVISION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    COMMIT=
+    COMMIT=$(curl_retry https://api.github.com/repos/cri-o/cri-o/tags | jq -r '.[] | select(.name == "'"$REVISION"'") | .commit.sha')
     PROJECT_VERSION=$(echo "$REVISION" | cut -c1-5)
     VERSION=${REVISION#v}
     PROJECT_TYPE=stable


### PR DESCRIPTION

#### What type of PR is this?


/kind ci

#### What this PR does / why we need it:
Avoiding GitHub actions races by:

- Waiting for jobs running for the same CRI-O commit
- Re-using the variables across the jobs

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
