### PR TITLE
systemd: Use `NetworkManager-wait-online.service` instead of `network-online.target`

### DIFF
--- a/templates/latest/cri-o/bundle/crio.service
+++ b/templates/latest/cri-o/bundle/crio.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Container Runtime Interface for OCI (CRI-O)
 Documentation=https://github.com/cri-o/cri-o
-Wants=network-online.target
+Wants=NetworkManager-wait-online.service
 Before=kubelet.service
-After=network-online.target
+After=NetworkManager-wait-online.service
 
 [Service]
 Type=notify


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:

We now wait until the network is fully up instead of just the `network-online.target`. Requires NetworkManager to be used on the system.

Ref: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/kubernetes/test-infra/pull/31115
#### Special notes for your reviewer:
@afbjorklund do you see any issue with that?
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Require NetworkManager for systemd unit and wait for `NetworkManager-wait-online.service` instead of `network-online.target`.
```
