### PR TITLE
Remove `crio-status` binary

### DIFF
--- a/get
+++ b/get
@@ -206,14 +206,12 @@ install $SELINUX -d -m 755 "$DESTDIR$FISHINSTALLDIR"
 install $SELINUX -d -m 755 "$DESTDIR$ZSHINSTALLDIR"
 install $SELINUX -d -m 755 "$DESTDIR$CONTAINERS_DIR"
 install $SELINUX -d -m 755 "$DESTDIR$CONTAINERS_REGISTRIES_CONFD_DIR"
-install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crio-status
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$ETCDIR" etc/crictl.yaml
 install $SELINUX -D -m 644 -t "$DESTDIR$OCIDIR" etc/crio-umount.conf
 install $SELINUX -D -m 644 -t "$DESTDIR$ETCDIR/crio/crio.conf.d" etc/10-crun.conf
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man5" man/crio.conf.5
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man5" man/crio.conf.d.5
-install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio-status.8
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
@@ -236,7 +234,6 @@ if [ -n "$SELINUX" ]; then
     if command -v chcon >/dev/null; then
         chcon -u system_u -r object_r -t container_runtime_exec_t \
             "$DESTDIR$BINDIR/crio" \
-            "$DESTDIR$BINDIR/crio-status" \
             "$DESTDIR$BINDIR/crun"
 
         if [ "$ARCH" = amd64 ]; then

--- a/scripts/bundle/build
+++ b/scripts/bundle/build
@@ -25,7 +25,6 @@ mkdir -p "$TMPDIR"/{bin,contrib,etc,man}
 BIN_URL="https://storage.googleapis.com/cri-o/artifacts/$COMMIT/$ARCH"
 FILES_BIN=(
     crio
-    crio-status
     pinns
 )
 
@@ -44,7 +43,6 @@ cp -r "$TMPDIR_CRIO/completions" "$TMPDIR"
 
 make -C "$TMPDIR_CRIO" docs
 FILES_MAN=(
-    "$TMPDIR_CRIO/docs/crio-status.8"
     "$TMPDIR_CRIO/docs/crio.8"
     "$TMPDIR_CRIO/docs/crio.conf.5"
     "$TMPDIR_CRIO/docs/crio.conf.d.5"
@@ -178,7 +176,7 @@ $BOM validate -e "$SPDX_PATH" -d "$CRIODIR"
 pushd "$TMPDIR"
 export DESTDIR=test/
 ./install
-EXP_CNT=68
+EXP_CNT=66
 if ! command -v runc; then
     EXP_CNT=$((EXP_CNT + 1))
 fi

--- a/templates/latest/cri-o/bundle/install
+++ b/templates/latest/cri-o/bundle/install
@@ -41,14 +41,12 @@ install $SELINUX -d -m 755 "$DESTDIR$FISHINSTALLDIR"
 install $SELINUX -d -m 755 "$DESTDIR$ZSHINSTALLDIR"
 install $SELINUX -d -m 755 "$DESTDIR$CONTAINERS_DIR"
 install $SELINUX -d -m 755 "$DESTDIR$CONTAINERS_REGISTRIES_CONFD_DIR"
-install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crio-status
 install $SELINUX -D -m 755 -t "$DESTDIR$BINDIR" bin/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$ETCDIR" etc/crictl.yaml
 install $SELINUX -D -m 644 -t "$DESTDIR$OCIDIR" etc/crio-umount.conf
 install $SELINUX -D -m 644 -t "$DESTDIR$ETCDIR/crio/crio.conf.d" etc/10-crun.conf
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man5" man/crio.conf.5
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man5" man/crio.conf.d.5
-install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio-status.8
 install $SELINUX -D -m 644 -t "$DESTDIR$MANDIR/man8" man/crio.8
 install $SELINUX -D -m 644 -t "$DESTDIR$BASHINSTALLDIR" completions/bash/crio
 install $SELINUX -D -m 644 -t "$DESTDIR$FISHINSTALLDIR" completions/fish/crio.fish
@@ -71,7 +69,6 @@ if [ -n "$SELINUX" ]; then
     if command -v chcon >/dev/null; then
         chcon -u system_u -r object_r -t container_runtime_exec_t \
             "$DESTDIR$BINDIR/crio" \
-            "$DESTDIR$BINDIR/crio-status" \
             "$DESTDIR$BINDIR/crun"
 
         if [ "$ARCH" = amd64 ]; then


### PR DESCRIPTION


#### What type of PR is this?


/kind deprecation

#### What this PR does / why we need it:
The binary is already deprecated so we do not have to ship it in v1.28 and beyond.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
Refers also to https://github.com/cri-o/cri-o/pull/7440
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `crio-status` binary in favor of the `crio status` subcommand.
```
