### PR TITLE
Run `release` step independent from test-kubernetes

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -268,8 +268,10 @@ jobs:
     name: release / ${{ inputs.revision || 'main' }}
     needs:
       - vars
-      - test-kubernetes
       - test-architectures
+      # TODO(saschagrunert): re-enable when
+      # https://github.com/actions/runner-images/issues/8730 is resolved
+      # - test-kubernetes
     steps:
       - uses: actions/checkout@v4
       - run: scripts/obs


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
We still need to run the release step, which got blocked by the deactivated `test-kubernetes` job.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
