### PR TITLE
Fix v1.x.0 version reconcile logic in script

### DIFF
--- a/scripts/reconcile
+++ b/scripts/reconcile
@@ -70,10 +70,12 @@ for PROJECT in $(echo "$PACKAGES" | grep "$PROJECT_STABLE_PREFIX:.*:build.*cri-o
         fi
     done
 
+    NO_VERSION_FOUND=0
     if [[ $VERSION == "" ]]; then
         VERSION=${PROJECT#"$PROJECT_STABLE_PREFIX:"}
         VERSION=${VERSION%"$BUILD_PROJECT_SUFFIX"}.0
         echo "No version found for project '$PROJECT', assuming $VERSION"
+        NO_VERSION_FOUND=1
     else
         echo "Found latest OBS version '$VERSION' for project: $PROJECT"
     fi
@@ -83,6 +85,9 @@ for PROJECT in $(echo "$PACKAGES" | grep "$PROJECT_STABLE_PREFIX:.*:build.*cri-o
         echo "No latest release found for OBS version '$VERSION'"
     elif [[ "$LATEST_VERSION" != "$VERSION" ]]; then
         echo "Latest release version '$LATEST_VERSION' is not matching OBS latest version '$VERSION'"
+        submit_workflow "$LATEST_VERSION"
+    elif [[ $NO_VERSION_FOUND == 1 ]]; then
+        echo "Latest release version '$LATEST_VERSION' is not existing in OBS"
         submit_workflow "$LATEST_VERSION"
     else
         echo "Latest release '$LATEST_VERSION' already available in project: $PROJECT"


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The script thinks the version already exists but we need a dedicated path for .0 releases.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
