### PR TITLE
Don't use CDN's for repo keys

### DIFF
--- a/test/deb/Dockerfile
+++ b/test/deb/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
         curl \
         software-properties-common
 
-RUN curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+RUN curl -fsSL "https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/Release.key" | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
 RUN echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
 
 RUN apt-get update && apt-get install -y cri-o

--- a/test/deb/Vagrantfile
+++ b/test/deb/Vagrantfile
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
 
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
-      curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/"$PROJECT_PATH":/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+      curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/"$PROJECT_PATH":/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
       apt-get update
 

--- a/test/deb/lima.yaml
+++ b/test/deb/lima.yaml
@@ -27,7 +27,7 @@ provision:
 
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
-      curl -fsSL https://pkgs.k8s.io/addons:/cri-o:/"$PROJECT_PATH":/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+      curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/"$PROJECT_PATH":/build/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
       apt-get update
 

--- a/test/rpm/Dockerfile
+++ b/test/rpm/Dockerfile
@@ -8,7 +8,7 @@ name=CRI-O\n\
 baseurl=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key\n\
+gpgkey=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key\n\
 " > /etc/yum.repos.d/cri-o.repo
 
 RUN dnf install -y \

--- a/test/rpm/Vagrantfile
+++ b/test/rpm/Vagrantfile
@@ -44,7 +44,7 @@ name=CRI-O
 baseurl=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/
 enabled=1
 gpgcheck=1
-gpgkey=https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key
+gpgkey=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key
 EOF
 
       # Official package dependencies

--- a/test/rpm/lima.yaml
+++ b/test/rpm/lima.yaml
@@ -42,7 +42,7 @@ provision:
     baseurl=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/
     enabled=1
     gpgcheck=1
-    gpgkey=https://pkgs.k8s.io/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key
+    gpgkey=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/rpm/repodata/repomd.xml.key
     EOF
 
       # Official package dependencies


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The keys are not available when the project is recently created because of the CDN caching. We avoid that by using the fallback URL's.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
