### PR TITLE
Add s390x architecture support to `get` script

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,8 +246,8 @@ its `$PATH`. The same applies to the [SPDX](https://spdx.org) based bill of
 materials (SBOM), which gets automatically verified if the
 [bom](https://sigs.k8s.io/bom) tool is in `$PATH`.
 
-Besides `amd64`, we also support the `arm64` and `ppc64le` bit architectures.
-This can be selected via the script, too:
+Besides `amd64`, we also support the `arm64`, `ppc64le` and `s390x` bit
+architectures. This can be selected via the script, too:
 
 ```shell
 curl https://raw.githubusercontent.com/cri-o/packaging/main/get | bash -s -- -a arm64
@@ -266,7 +266,7 @@ tarball matching the format:
 https://storage.googleapis.com/cri-o/artifacts/cri-o.$ARCH.$REV.tar.gz
 ```
 
-Where `$ARCH` can be `amd64` or `arm64` or `ppc64le` and `$REV`
+Where `$ARCH` can be `amd64`, `arm64`, `ppc64le` or `s390x` and `$REV`
 can be any git SHA or tag.
 
 We also provide a Software Bill of Materials (SBOM) in the [SPDX

--- a/get
+++ b/get
@@ -4,6 +4,7 @@ set -euo pipefail
 ARCH_AMD64=amd64
 ARCH_ARM64=arm64
 ARCH_PPC64LE=ppc64le
+ARCH_S390X=s390x
 ARCH=
 VERSION=
 GCB_URL=https://storage.googleapis.com/cri-o
@@ -53,6 +54,8 @@ parse_args() {
             ARCH=$ARCH_ARM64
         elif [[ "$LOCAL_ARCH" == "$ARCH_PPC64LE" ]]; then
             ARCH=$ARCH_PPC64LE
+        elif [[ "$LOCAL_ARCH" == "$ARCH_S390X" ]]; then
+            ARCH=$ARCH_S390X
         else
             echo "Unsupported local architecture: $LOCAL_ARCH"
             exit 1


### PR DESCRIPTION

#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Allow `s390x` as possible arch for the `get` script.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Refers to https://github.com/cri-o/cri-o/pull/7821
#### Special notes for your reviewer:
/hold

for https://github.com/cri-o/cri-o/pull/7821 to be merged first.
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added s390x architecture support to `get` script 
```
