### PR TITLE
Remove `criu` dependency and increase test timeouts

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -105,10 +105,6 @@ jobs:
         with:
           name: bundles-amd64
           path: build/bundle
-      - name: Install criu dependency
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y criu
       - run: sudo -E scripts/bundle/test
         if: ${{ inputs.skip-bundles == false }}
         env:

--- a/scripts/bundle/test
+++ b/scripts/bundle/test
@@ -29,7 +29,7 @@ crictl version
 CONTAINER_JSON="$GIT_ROOT/test/testdata/container.json"
 POD_JSON="$GIT_ROOT/test/testdata/pod.json"
 
-crictl run "$CONTAINER_JSON" "$POD_JSON"
+crictl -t=1m run "$CONTAINER_JSON" "$POD_JSON"
 
 # Test the workloads status
 POD_NAME=$(jq -r .metadata.name "$POD_JSON")
@@ -45,5 +45,5 @@ if [[ ! $(crictl ps --name "$CONTAINER_NAME" --state Exited -q) ]]; then
 fi
 
 # Cleanup
-crictl rmp -fa
+crictl -t=1m rmp -fa
 systemctl stop crio

--- a/test/deb/Vagrantfile
+++ b/test/deb/Vagrantfile
@@ -33,9 +33,6 @@ Vagrant.configure("2") do |config|
       echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
       apt-get update
 
-      # Official package dependencies
-      apt-get install -y criu
-
       apt-get install -y cri-o kubelet kubeadm kubectl
       systemctl start crio
 

--- a/test/deb/lima.yaml
+++ b/test/deb/lima.yaml
@@ -31,9 +31,6 @@ provision:
       echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/$PROJECT_PATH:/build/deb/ /" | tee /etc/apt/sources.list.d/cri-o.list
       apt-get update
 
-      # Official package dependencies
-      apt-get install -y criu
-
       apt-get install -y cri-o kubelet kubeadm kubectl
       systemctl start crio
 

--- a/test/rpm/Vagrantfile
+++ b/test/rpm/Vagrantfile
@@ -48,7 +48,7 @@ gpgkey=https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o
 EOF
 
       # Official package dependencies
-      dnf install -y container-selinux criu
+      dnf install -y container-selinux
 
       dnf install -y cri-o kubelet kubeadm kubectl
       systemctl start crio

--- a/test/rpm/lima.yaml
+++ b/test/rpm/lima.yaml
@@ -46,7 +46,7 @@ provision:
     EOF
 
       # Official package dependencies
-      dnf install -y container-selinux criu
+      dnf install -y container-selinux
 
       dnf install -y cri-o kubelet kubeadm kubectl
       systemctl start crio


### PR DESCRIPTION

#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We do not need `criu` any more as runtime dependency, which is now reflected in the tests. We also increase the `crictl run/rmp` timeouts to deflake the bundle test. 

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
