### PR TITLE
Fix package deletion for projects with less than max items

### DIFF
--- a/scripts/reconcile
+++ b/scripts/reconcile
@@ -47,12 +47,12 @@ for PROJECT in $(echo "$PACKAGES" | grep "$PROJECT_PRERELEASE_PREFIX:.*:build.*c
         for ((i = 0; i < MAX_LEN; i++)); do
             unset 'RELEASE_PACKAGES[-1]'
         done
-    fi
 
-    echo "Keeping last $MAX_LEN packages in project $RELEASE_PROJECT, removing the rest"
-    for PACKAGE in "${RELEASE_PACKAGES[@]}"; do
-        osc rdelete -m cleanup "$RELEASE_PROJECT" "$PACKAGE"
-    done
+        echo "Keeping last $MAX_LEN packages in project $RELEASE_PROJECT, removing the rest"
+        for PACKAGE in "${RELEASE_PACKAGES[@]}"; do
+            osc rdelete -m cleanup "$RELEASE_PROJECT" "$PACKAGE"
+        done
+    fi
 done
 
 PREFIX=cri-o_


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We only have to remove packages when we have less than the maximum amount of items. This patch fixes that logic.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes see:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
