### PR TITLE
Remove release note from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -66,15 +66,9 @@ None
 #### Does this PR introduce a user-facing change?
 
 <!--
-If no, just write `None` in the release-note block below. If yes, a release note
-is required: Enter your extended release note in the block below. If the PR
-requires additional action from users switching to the new release, include the
-string "action required".
-
-For more information on release notes see:
-https://git.k8s.io/community/contributors/guide/release-notes.md
+No releases for this repository.
 -->
 
 ```release-note
-
+None
 ```


### PR DESCRIPTION
#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
We usually do no releases from this repo, means we can default to a `release-note-none`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
PTAL @cri-o/cri-o-maintainers 
#### Does this PR introduce a user-facing change?

```release-note
None
```
