### PR TITLE
Retry GitHub job watch

### DIFF
--- a/scripts/github-job-wait
+++ b/scripts/github-job-wait
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
+source "$(dirname "${BASH_SOURCE[0]}")"/helpers
+
 COMMIT=${COMMIT:-}
 if [[ "$COMMIT" == "" ]]; then
     echo "No commit provided"
@@ -16,6 +18,6 @@ for ID in $(gh run list -s in_progress -w obs --json databaseId -q '.[] | .datab
 
     if [[ "$RUNNING_COMMIT" == "$COMMIT" ]]; then
         echo "Job for commit '$COMMIT' is already running, waiting for it to complete"
-        gh run watch "$ID"
+        retry_3 gh run watch "$ID"
     fi
 done


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
From time to time the job watch throws a 502 error:

```
failed to get jobs: HTTP 502: Server Error (https://api.github.com/repos/cri-o/packaging/actions/runs/8682352551/jobs?per_page=100)
```

We now retry up to three times to make the test suite robust.

#### Which issue(s) this PR fixes:

As follow-up, I opened: https://github.com/cli/go-gh/issues/157

#### Special notes for your reviewer:
PTAL @cri-o/cri-o-maintainers 
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
