### PR TITLE
Explicitly set runtime_root in the default config

### DIFF
--- a/templates/latest/cri-o/bundle/10-crio.conf
+++ b/templates/latest/cri-o/bundle/10-crio.conf
@@ -6,6 +6,7 @@ default_runtime = "crun"
 
 [crio.runtime.runtimes.crun]
 runtime_path = "/usr/bin/crio-crun"
+runtime_root = "/run/crun"
 monitor_path = "/usr/bin/crio-conmon"
 allowed_annotations = [
     "io.containers.trace-syscall",
@@ -13,4 +14,5 @@ allowed_annotations = [
 
 [crio.runtime.runtimes.runc]
 runtime_path = "/usr/bin/crio-runc"
+runtime_root = "/run/runc"
 monitor_path = "/usr/bin/crio-conmon"


### PR DESCRIPTION
#### What type of PR is this?

/kind other

#### What this PR does / why we need it:

This PR fixes a small nuisance where the default `crun` runtime writes its status to `/run/runc`, which is the default `runtime_root` value.

#### Which issue(s) this PR fixes:

Fixes #104 

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
In the default configuration, the crun runtime will now store its state to /run/crun instead of /run/runc.
```
