### PR TITLE
Change `/etc/sysconfig` to `/etc/default` for debian distributions

### DIFF
--- a/templates/latest/cri-o/cri-o.spec
+++ b/templates/latest/cri-o/cri-o.spec
@@ -80,6 +80,12 @@ install -p -m 644 %{archive_root}/contrib/11-crio-ipv4-bridge.conflist %{buildro
 
 # Fix the prefix in crio.service
 sed -i 's;/usr/local/bin;/usr/bin;g' %{archive_root}/contrib/crio.service
+
+# Fix the /etc/sysconfig path for debian based distributions
+%if "%{_vendor}" == "debbuild"
+sed -i 's;/etc/sysconfig/crio;/etc/default/crio;g' %{archive_root}/contrib/crio.service
+%endif
+
 install -D -m 644 -t %{buildroot}%{_unitdir} %{archive_root}/contrib/crio.service
 
 # Docs


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Changing to `/etc/default` for debian based distributions.
#### Which issue(s) this PR fixes:

Fixes https://github.com/cri-o/cri-o/issues/8315


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
