### PR TITLE
Add rpmlintrc to make RPM build

### DIFF
--- a/templates/latest/cri-o/cri-o.rpmlintrc
+++ b/templates/latest/cri-o/cri-o.rpmlintrc
@@ -1,0 +1,5 @@
+# Ignore "suse-filelist-forbidden-sysconfig" because we can't use "fillup" in
+# our specs. That's because we want to build on SUSE Linux, but use resulting
+# packages on other RPM-based operating systems. This is not possible if
+# "fillup" is used.
+setBadness('suse-filelist-forbidden-sysconfig', 0)

--- a/templates/latest/cri-o/cri-o.spec
+++ b/templates/latest/cri-o/cri-o.spec
@@ -9,6 +9,7 @@ Packager: Kubernetes Authors <dev@kubernetes.io>
 License: Apache-2.0
 URL: https://kubernetes.io
 Source0: %{name}_%{version}.orig.tar.gz
+Source1: %{name}.rpmlintrc
 BuildRequires: sed
 BuildRequires: systemd
 %{?systemd_requires}


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
We cannot use fillup in the RPMs, so we skip that lint. Kubernetes does the same.
#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
