### PR TITLE
Add `run-name` for OBS workflow

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -28,6 +28,8 @@ env:
   REVISION: ${{ inputs.revision || 'main' }}
   OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
 
+run-name: publish on OBS / ${{ inputs.revision || 'main' }}
+
 jobs:
   vars:
     runs-on: ubuntu-latest


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
This allows to directly identify the used branch on the obs workflow name rather than just `obs`.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
