### PR TITLE
Make vagrant in CI available

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-apt-get update
-apt-get install -y \
-    libvirt-daemon-system \
-    qemu-kvm \
-    vagrant
+curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
 
-systemctl enable --now libvirtd
+apt-get update
+apt-get install -y vagrant virtualbox


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The vagrant package does not seem to be available any more, so we use them from HashiCorp.
#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
