### PR TITLE
CRI-O is no longer a subproject of Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ dedicated repository, following official Kubernetes guidelines by using the
 
 ## Project Layout
 
-CRI-O uses the same basic project layout in OBS as Kubernetes, but lives in a
-dedicated umbrella subproject called [`isv:cri-o`](https://build.opensuse.org/project/show/isv:cri-o).
+CRI-O uses the same basic layout in OBS as Kubernetes project [`isv:kubernetes`](https://build.opensuse.org/project/show/isv:kubernetes),
+but lives in a dedicated umbrella project called [`isv:cri-o`](https://build.opensuse.org/project/show/isv:cri-o).
 
 This project contains a bunch of other [subprojects](https://build.opensuse.org/project/subprojects/isv:cri-o):
 


### PR DESCRIPTION
The text mentioned a "dedicated umbrella SUBproject", but now it has been moved to a separate project (under "isv").

Also it is no longer obvious where to find "kubernetes", since it is no longer the parent of the subproject - add link.

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind documentation

#### What this PR does / why we need it:

Clarify the projects/subprojects in OBS

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

* #221 

#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
