### PR TITLE
fix verify command

### DIFF
--- a/get
+++ b/get
@@ -128,9 +128,7 @@ if command -v cosign >/dev/null; then
     done
 
     GIT_REF=refs/heads/main
-    if git ls-remote --exit-code --tags https://github.com/cri-o/cri-o "refs/tags/$VERSION" >/dev/null; then
-        GIT_REF="refs/tags/$VERSION"
-    fi
+
     BLOBS=(
         "$TARBALL"
         "$SPDX"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->
/kind bug
<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

This PR fixes GIT_REF when tag is specified.
Verified locally.
```
❯ cat get | sudo bash -s -- -t v1.33.1
Welcome to the CRI-O install script!
Using version: v1.33.1
No architecture provided, using: amd64
Checking if all commands are available: curl jq tar
Found cosign, verifying signatures
Downloading cri-o.amd64.v1.33.1.tar.gz
Downloading cri-o.amd64.v1.33.1.tar.gz.sig
Downloading cri-o.amd64.v1.33.1.tar.gz.cert
Downloading cri-o.amd64.v1.33.1.tar.gz.spdx
Downloading cri-o.amd64.v1.33.1.tar.gz.spdx.sig
Downloading cri-o.amd64.v1.33.1.tar.gz.spdx.cert
Verifying blob cri-o.amd64.v1.33.1.tar.gz
Verified OK
Verifying blob cri-o.amd64.v1.33.1.tar.gz.spdx
Verified OK
/tmp/tmp.H3YuuLdNS1/cri-o /tmp/tmp.H3YuuLdNS1 /home/atokubi/cri-o/packaging
Installing CRI-O
+ DESTDIR=
+ PREFIX=/usr/local
+ ETCDIR=/etc
+ LIBEXECDIR=/usr/libexec
+ LIBEXEC_CRIO_DIR=/usr/libexec/crio
+ ETC_CRIO_DIR=/etc/crio
+ CONTAINERS_DIR=/etc/containers
+ CONTAINERS_REGISTRIES_CONFD_DIR=/etc/containers/registries.conf.d
+ CNIDIR=/etc/cni/net.d
+ BINDIR=/usr/local/bin
+ MANDIR=/usr/local/share/man
+ OCIDIR=/usr/local/share/oci-umount/oci-umount.d
+ BASHINSTALLDIR=/usr/local/share/bash-completion/completions
+ FISHINSTALLDIR=/usr/local/share/fish/completions
+ ZSHINSTALLDIR=/usr/local/share/zsh/site-functions
+ OPT_CNI_BIN_DIR=/opt/cni/bin
+ dpkg -l
+ SYSCONFIGDIR=/etc/default
+ sed -i 's;sysconfig/crio;default/crio;g' etc/crio
+ source /etc/os-release
++ PRETTY_NAME='Ubuntu 25.04'
++ NAME=Ubuntu
++ VERSION_ID=25.04
++ VERSION='25.04 (Plucky Puffin)'
++ VERSION_CODENAME=plucky
++ ID=ubuntu
++ ID_LIKE=debian
++ HOME_URL=https://www.ubuntu.com/
++ SUPPORT_URL=https://help.ubuntu.com/
++ BUG_REPORT_URL=https://bugs.launchpad.net/ubuntu/
++ PRIVACY_POLICY_URL=https://www.ubuntu.com/legal/terms-and-policies/privacy-policy
++ UBUNTU_CODENAME=plucky
++ LOGO=ubuntu-logo
+ [[ ubuntu == \f\e\d\o\r\a ]]
+ [[ ubuntu == \r\h\c\o\s ]]
+ SYSTEMDDIR=/usr/local/lib/systemd/system
+ SELINUX=
+ selinuxenabled
+ ARCH=amd64
+ install -d -m 755 /etc/cni/net.d
+ install -D -m 755 -t /opt/cni/bin cni-plugins/LICENSE cni-plugins/README.md cni-plugins/bandwidth cni-plugins/bridge cni-plugins/dhcp cni-plugins/dummy cni-plugins/firewall cni-plugins/host-device cni-plugins/host-local cni-plugins/ipvlan cni-plugins/loopback cni-plugins/macvlan cni-plugins/portmap cni-plugins/ptp cni-plugins/sbr cni-plugins/static cni-plugins/tap cni-plugins/tuning cni-plugins/vlan cni-plugins/vrf
+ install -D -m 644 -t /etc/cni/net.d contrib/10-crio-bridge.conflist.disabled
+ install -d -m 755 /usr/libexec/crio
+ install -D -m 755 -t /usr/libexec/crio bin/conmon
+ install -D -m 755 -t /usr/libexec/crio bin/conmonrs
+ install -D -m 755 -t /usr/libexec/crio bin/crun
+ install -D -m 755 -t /usr/libexec/crio bin/runc
+ install -d -m 755 /usr/local/share/bash-completion/completions
+ install -d -m 755 /usr/local/share/fish/completions
+ install -d -m 755 /usr/local/share/zsh/site-functions
+ install -d -m 755 /etc/containers/registries.conf.d
+ install -D -m 755 -t /usr/local/bin bin/crio
+ install -D -m 755 -t /usr/local/bin bin/pinns
+ install -D -m 755 -t /usr/local/bin bin/crictl
+ install -D -m 644 -t /etc etc/crictl.yaml
+ install -D -m 644 -t /usr/local/share/oci-umount/oci-umount.d etc/crio-umount.conf
+ install -D -m 644 -t /etc/default etc/crio
+ install -D -m 644 -t /etc/crio contrib/policy.json
+ install -D -m 644 -t /etc/crio/crio.conf.d etc/10-crio.conf
+ install -D -m 644 -t /usr/local/share/man/man5 man/crio.conf.5
+ install -D -m 644 -t /usr/local/share/man/man5 man/crio.conf.d.5
+ install -D -m 644 -t /usr/local/share/man/man8 man/crio.8
+ install -D -m 644 -t /usr/local/share/bash-completion/completions completions/bash/crio
+ install -D -m 644 -t /usr/local/share/fish/completions completions/fish/crio.fish
+ install -D -m 644 -t /usr/local/share/zsh/site-functions completions/zsh/_crio
+ install -D -m 644 -t /usr/local/lib/systemd/system contrib/crio.service
+ install -D -m 644 -t /etc/containers/registries.conf.d contrib/registries.conf
+ sed -i 's;/usr/bin;/usr/local/bin;g' /etc/crio/crio.conf.d/10-crio.conf
+ sed -i 's;/usr/libexec;/usr/libexec;g' /etc/crio/crio.conf.d/10-crio.conf
+ sed -i 's;/etc/crio;/etc/crio;g' /etc/crio/crio.conf.d/10-crio.conf
+ '[' -n '' ']'
+ rm -rf -- /tmp/tmp.H3YuuLdNS1
```


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
