### PR TITLE
Avoid expanding unqualified images to quay.io

### DIFF
--- a/templates/latest/cri-o/bundle/registries.conf
+++ b/templates/latest/cri-o/bundle/registries.conf
@@ -1,1 +1,1 @@
-unqualified-search-registries = ["docker.io", "quay.io"]
+unqualified-search-registries = ["docker.io"]


### PR DESCRIPTION

<!--  Thanks for sending a pull request!

Please be aware that we're following the Kubernetes guidelines of contributing
to this project. This means that we have to use this mandatory template for all
of our pull requests.

Please also make sure you've read and understood our contributing guidelines
(https://github.com/cri-o/cri-o/blob/main/CONTRIBUTING.md) as well as ensuring
that all your commits are signed with `git commit -s`.

Here are some additional tips for you:

- If this is your first time, please read our contributor guidelines:
  https://git.k8s.io/community/contributors/guide#your-first-contribution and
  developer guide
  https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are
  addressing, especially if this is a release targeted pull request. For
  reference on required PR/issue labels, read here:
  https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it:
  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Uncomment only one `/kind <>` line, hit enter to put that in a new line, and
remove leading whitespace from that line:
-->

/kind bug

<!--
/kind api-change
/kind bug
/kind ci
/kind cleanup
/kind dependency-change
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind feature
/kind flake
/kind other
-->

#### What this PR does / why we need it:

In general unqualified will in most cases (still) refer to docker.io. With this change unqualified container images will no longer be resolved to `quay.io`, e.g. `debian:stable` will only resolve to `docker.io/library/debian:stable` but not to `quay.io/debian:stable` anymore.

This will avoid shadowing errors when pulling from `docker.io` with non-existent container image references to `quay.io`.


#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #301 


<!--
Fixes #
or
None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

This changes the default behavior of resolving unqualified container image names on image pull. 


<!--
No releases for this repository.
-->

<!--
```release-note
None
```
-->
