### PR TITLE
Fix the AMD-V extension issue with VirtualBox

### DIFF
--- a/scripts/github-actions-setup
+++ b/scripts/github-actions-setup
@@ -4,5 +4,9 @@ set -euox pipefail
 curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
 
+# Fix the error: VirtualBox can't enable the AMD-V extension. Please disable
+# the KVM kernel extension, recompile your kernel and reboot (VERR_SVM_IN_USE).
+rmmod kvm_amd
+
 apt-get update
 apt-get install -y vagrant virtualbox


### PR DESCRIPTION

#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Fix the issue reported in CI:

> VirtualBox can't enable the AMD-V extension. Please disable the KVM
> kernel extension, recompile your kernel and reboot (VERR_SVM_IN_USE).

https://github.com/cri-o/packaging/actions/runs/18650858497/job/53168401216

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
