### PR TITLE
Add automatic retry to bundles and test-architectures jobs

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -77,8 +77,13 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
-      - run: scripts/bundle/build
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         if: ${{ inputs.skip-bundles == false }}
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: scripts/bundle/build
         env:
           ARCH: ${{ matrix.arch }}
           ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
@@ -314,8 +319,13 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-      - run: scripts/test-architectures
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         if: ${{ inputs.skip-tests == false }}
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: scripts/test-architectures
         env:
           IMAGE: ${{ matrix.run.image }}
           ARCH: ${{ matrix.arch }}


### PR DESCRIPTION
#### What type of PR is this?

/kind ci

#### What this PR does / why we need it:

This PR adds automatic retry mechanisms to the `bundles` and `test-architectures` jobs in the OBS workflow using the `nick-fields/retry@v3.0.2` action.

Both jobs will now automatically retry up to 3 times with:
- 60-second wait between retry attempts
- 30-minute timeout per attempt

This improves reliability by handling transient failures from:
- Network connectivity problems
- Rate limiting
- Temporary infrastructure issues
- Race conditions in multi-arch testing
- Dependency download failures during builds

**Jobs affected:**
- `bundles`: Multi-architecture builds (amd64, arm64, ppc64le, s390x)
- `test-architectures`: Tests across multiple distros and architectures

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

The retry action uses pinned commit hash `ce71cc2ab81d554ebbe88c79ab5975992d79ba08` corresponding to v3.0.2 for security and reproducibility.

Example run for requiring 2 attempts: https://github.com/cri-o/packaging/actions/runs/19267943572/job/55088498998?pr=314

#### Does this PR introduce a user-facing change?

```release-note
None
```