### PR TITLE
Exclude AlmaLinux 10 s390x from architecture tests

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -315,6 +315,9 @@ jobs:
           - run:
               image: fedora:39
             arch: arm64 # takes forever
+          - run:
+              image: almalinux:10
+            arch: s390x # QEMU emulation segfault
     name: test / ${{ matrix.run.type }} / ${{ matrix.run.image }} / ${{ matrix.arch }}
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION


#### What type of PR is this?


/kind ci


#### What this PR does / why we need it:
The s390x architecture test fails on AlmaLinux 10 due to QEMU emulation issues causing dnf to segfault during package installation. This is a known limitation of QEMU user-mode emulation with s390x on newer distributions.

Other architectures (amd64, arm64, ppc64le) continue to be tested on AlmaLinux 10, and s390x continues to be tested on other distributions.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```
