### PR TITLE
Add common 'After Installation' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,15 @@ dedicated repository, following official Kubernetes guidelines by using the
     - [Add the CRI-O repository](#add-the-cri-o-repository)
     - [Install package dependencies from the official repositories](#install-package-dependencies-from-the-official-repositories)
     - [Install the packages](#install-the-packages)
-    - [Configure a Container Network Interface (CNI) plugin](#configure-a-container-network-interface-cni-plugin)
-    - [Start CRI-O](#start-cri-o)
-    - [Bootstrap a cluster](#bootstrap-a-cluster)
   - [Distributions using <code>deb</code> packages](#distributions-using-deb-packages)
     - [Install the dependencies for adding repositories](#install-the-dependencies-for-adding-repositories)
     - [Add the Kubernetes repository](#add-the-kubernetes-repository-1)
     - [Add the CRI-O repository](#add-the-cri-o-repository-1)
     - [Install the packages](#install-the-packages-1)
-    - [Start CRI-O](#start-cri-o-1)
-    - [Bootstrap a cluster](#bootstrap-a-cluster-1)
+- [After Installation](#after-installation)
+  - [Configure a Container Network Interface (CNI) plugin](#configure-a-container-network-interface-cni-plugin)
+  - [Start CRI-O](#start-cri-o)
+  - [Bootstrap a cluster](#bootstrap-a-cluster)
 - [Publishing](#publishing)
 - [Using the static binary bundles directly](#using-the-static-binary-bundles-directly)
 - [Uninstall the static binary bundles](#uninstall-the-static-binary-bundles)
@@ -198,38 +197,6 @@ dnf install -y container-selinux
 dnf install -y cri-o kubelet kubeadm kubectl
 ```
 
-#### Configure a Container Network Interface (CNI) plugin
-
-CRI-O is capable of working with different [CNI plugins](https://github.com/containernetworking/cni),
-which may require a custom configuration. The CRI-O package ships a default
-[IPv4 and IPv6 (dual stack) configuration](templates/latest/cri-o/bundle/10-crio-bridge.conflist.disabled)
-for the [`bridge`](https://www.cni.dev/plugins/current/main/bridge) plugin,
-which is disabled by default. The configuration can be enabled by renaming the
-disabled configuration file in `/etc/cni/net.d`:
-
-```bash
-mv /etc/cni/net.d/10-crio-bridge.conflist.disabled /etc/cni/net.d/10-crio-bridge.conflist
-```
-
-The bridge plugin is suitable for single-node clusters in CI and testing
-environments. Different CNI plugins are recommended to use CRI-O in production.
-
-#### Start CRI-O
-
-```bash
-systemctl start crio.service
-```
-
-#### Bootstrap a cluster
-
-```bash
-swapoff -a
-modprobe br_netfilter
-sysctl -w net.ipv4.ip_forward=1
-
-kubeadm init
-```
-
 ### Distributions using `deb` packages
 
 #### Install the dependencies for adding repositories
@@ -266,13 +233,33 @@ apt-get update
 apt-get install -y cri-o kubelet kubeadm kubectl
 ```
 
-#### Start CRI-O
+## After Installation
+
+The following steps are common for both `rpm` and `deb` based distributions.
+
+### Configure a Container Network Interface (CNI) plugin
+
+CRI-O is capable of working with different [CNI plugins](https://github.com/containernetworking/cni),
+which may require a custom configuration. The CRI-O package ships a default
+[IPv4 and IPv6 (dual stack) configuration](templates/latest/cri-o/bundle/10-crio-bridge.conflist.disabled)
+for the [`bridge`](https://www.cni.dev/plugins/current/main/bridge) plugin,
+which is disabled by default. The configuration can be enabled by renaming the
+disabled configuration file in `/etc/cni/net.d`:
+
+```bash
+mv /etc/cni/net.d/10-crio-bridge.conflist.disabled /etc/cni/net.d/10-crio-bridge.conflist
+```
+
+The bridge plugin is suitable for single-node clusters in CI and testing
+environments. Different CNI plugins are recommended to use CRI-O in production.
+
+### Start CRI-O
 
 ```bash
 systemctl start crio.service
 ```
 
-#### Bootstrap a cluster
+### Bootstrap a cluster
 
 ```bash
 swapoff -a


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
Move CNI plugin configuration, CRI-O startup, and cluster bootstrap steps to a shared section. This ensures deb package users have the necessary CNI configuration to avoid NotReady nodes.

#### Which issue(s) this PR fixes:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

<!--
Fixes #
or
None
-->
Fixes https://github.com/cri-o/packaging/issues/324
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
No releases for this repository.
-->

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README documentation by introducing a dedicated "After Installation" section that consolidates post-installation steps. Container Network Interface configuration, service startup, and cluster bootstrap instructions are now standardized and consistently presented across all distribution-specific installation guides, improving documentation clarity, consistency, and user experience throughout the installation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->