### PR TITLE
Add SLSA provenance via tejolote and use release-actions

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -77,6 +77,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - uses: kubernetes-sigs/release-actions/setup-bom@cbe0488670ad0c0ff422fbef963da3bfe451a891 # v0.4.2
+        if: ${{ inputs.skip-bundles == false }}
       - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         if: ${{ inputs.skip-bundles == false }}
         with:
@@ -139,6 +141,8 @@ jobs:
           credentials_json: ${{ secrets.GCS_CRIO_SA }}
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+      - uses: kubernetes-sigs/release-actions/setup-tejolote@cbe0488670ad0c0ff422fbef963da3bfe451a891 # v0.4.2
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
         with:
@@ -165,6 +169,14 @@ jobs:
           ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
           COMMIT: ${{ needs.vars.outputs.commit }}
           PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+      - run: scripts/provenance
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+        env:
+          ARCHIVE_PATH: ${{ needs.vars.outputs.archive_path }}
+          COMMIT: ${{ needs.vars.outputs.commit }}
+          PROJECT_TYPE: ${{ needs.vars.outputs.project_type }}
+          REVISION: ${{ env.REVISION }}
+          GITHUB_TOKEN: ${{ github.token }}
       - run: scripts/sign-artifacts
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
       - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
@@ -191,13 +203,20 @@ jobs:
           path: |
             build/bundle/*.sig
             build/bundle/*.cert
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+        with:
+          name: attestations
+          path: |
+            build/bundle/*.openvex.json
+            build/bundle/*.provenance.json
 
   oci-artifacts-publish:
     name: oci-artifacts / publish / ${{ inputs.revision || 'main' }}
     runs-on: ubuntu-latest
     needs:
       - vars
-      - bundle-test
+      - bundles-publish
     permissions:
       contents: read
       id-token: write
@@ -211,6 +230,8 @@ jobs:
           username: cri-o
           password: ${{ secrets.GITHUB_TOKEN }}
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+      - uses: kubernetes-sigs/release-actions/setup-bom@cbe0488670ad0c0ff422fbef963da3bfe451a891 # v0.4.2
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
       - uses: oras-project/setup-oras@f0fe559615f43dcb02b17c56800daa7542ee0f91 # main (ORAS 1.3.1 support)
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
@@ -235,6 +256,11 @@ jobs:
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
         with:
           name: bundles-s390x
+          path: build/bundle
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+        with:
+          name: attestations
           path: build/bundle
       - run: scripts/oci-artifacts
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,14 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+      - uses: kubernetes-sigs/release-actions/setup-bom@cbe0488670ad0c0ff422fbef963da3bfe451a891 # v0.4.2
       - run: make verify-get-script
-      - name: Install BOM
-        run: |
-          BOM_VERSION=v0.7.1
-          curl -sSfL --retry 5 --retry-delay 3 -o bom \
-            https://github.com/kubernetes-sigs/bom/releases/download/$BOM_VERSION/bom-amd64-linux
-          chmod +x bom
-          sudo cp bom /usr/bin
       - run: sudo -E PATH=$PATH ./get
       - run: crio version
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,18 @@ like the bundle itself, but suffixed with `.spdx`:
 https://storage.googleapis.com/cri-o/artifacts/cri-o.$ARCH.$REV.tar.gz.spdx
 ```
 
+An [OpenVEX](https://openvex.dev) vulnerability report and [SLSA](https://slsa.dev)
+provenance attestation are available per release:
+
+```text
+https://storage.googleapis.com/cri-o/artifacts/cri-o.$REV.openvex.json
+https://storage.googleapis.com/cri-o/artifacts/cri-o.$REV.provenance.json
+```
+
+All artifacts and their attestations are signed using
+[sigstore](https://www.sigstore.dev/) and can be verified with
+[cosign](https://github.com/sigstore/cosign).
+
 ## Uninstall the static binary bundles
 
 ```console
@@ -419,22 +431,23 @@ The artifacts are also signed by [sigstore](https://www.sigstore.dev/):
 …
 ```
 
-The corresponding Software Bill of Materials (SBOM) is attached to the related
-artifact:
+The corresponding Software Bill of Materials (SBOM), [OpenVEX](https://openvex.dev)
+vulnerability report, and [SLSA](https://slsa.dev) provenance attestation are
+attached to the related artifact and signed:
 
 ```console
-> oras discover --platform linux/amd64 ghcr.io/cri-o/bundle:main
+> oras discover ghcr.io/cri-o/bundle:main
 
-ghcr.io/cri-o/bundle@sha256:71c6fbca2330d73faeda5632bc8e1f137ecefc0faee644013009fd3104db146b
-└── application/vnd.cncf.spdx.file.v1
-    └── sha256:ca4ca75e9999997e5ab753bd606f81115678f67891611906d9a0ecfad42dfe07
-        └── [annotations]
-            ├── org.cncf.cri-o.project: main
-            ├── org.cncf.cri-o.version: v1.33.0-dev
-            ├── org.opencontainers.image.created: "2025-04-25T01:37:00Z"
-            ├── org.cncf.cri-o.branch: main
-            └── org.cncf.cri-o.commit: 17ac08c0c9976930f7d66896307bf46249223b1c
+ghcr.io/cri-o/bundle@sha256:...
+├── application/vnd.cncf.spdx.file.v1
+├── application/vnd.cncf.openvex.file.v1
+└── application/vnd.cncf.slsa.provenance.v1
+```
 
+The SBOM is attached per architecture, while VEX and provenance are attached to
+the multi-arch index. To pull a specific attachment:
+
+```console
 > oras pull $(oras discover --platform linux/amd64 --format json ghcr.io/cri-o/bundle:main | jq -r .referrers[0].reference)
 …
 ```

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -102,14 +102,6 @@ dependencies:
       - path: scripts/helpers
         match: KREL_VERSION
 
-  - name: bom
-    version: v0.7.1
-    refPaths:
-      - path: scripts/helpers
-        match: BOM_VERSION
-      - path: .github/workflows/test.yml
-        match: BOM_VERSION
-
   - name: oras
     version: 1.3.1
     refPaths:

--- a/scripts/bundle/build
+++ b/scripts/bundle/build
@@ -153,8 +153,6 @@ for FILE in "$TMP_BIN"/*; do
     fi
 done
 
-install_bom
-
 # Create the SBOM
 pushd "$ARCHIVE_PATH"
 SPDX_FILE="$ARCHIVE.spdx"

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -34,11 +34,6 @@ install_krel() {
     install_binary https://github.com/kubernetes/release/releases/download/$KREL_VERSION/krel-amd64-linux krel
 }
 
-install_bom() {
-    BOM_VERSION=v0.7.1
-    install_binary https://github.com/kubernetes-sigs/bom/releases/download/$BOM_VERSION/bom-amd64-linux bom
-}
-
 install_binary() {
     curl_retry "$1" -o "$2"
     chmod +x "$2"

--- a/scripts/oci-artifacts
+++ b/scripts/oci-artifacts
@@ -9,9 +9,9 @@ ARTIFACT=$REGISTRY/bundle
 ARCHES=(amd64 arm64 ppc64le s390x)
 BUNDLE_ARTIFACT_TYPE=application/vnd.cncf.cri-o.bundle.v1
 SBOM_ARTIFACT_TYPE=application/vnd.cncf.spdx.file.v1
+VEX_ARTIFACT_TYPE=application/vnd.cncf.openvex.file.v1
+PROVENANCE_ARTIFACT_TYPE=application/vnd.cncf.slsa.provenance.v1
 SBOM_FILE=sbom.spdx
-
-install_bom
 
 pushd "$ARCHIVE_PATH"
 
@@ -106,3 +106,37 @@ for ARCH in "${ARCHES[@]}"; do
     popd
     cosign sign -y "$SBOM_REF"
 done
+
+# Attach VEX report to multi-arch index if available.
+VEX_FILE="cri-o.$ARCHIVE_ID.openvex.json"
+if [[ -e "$VEX_FILE" ]]; then
+    VEX_REF=$(
+        oras attach \
+            -a "$ANNOTATION_VERSION" \
+            -a "$ANNOTATION_COMMIT" \
+            -a "$ANNOTATION_BRANCH" \
+            -a "$ANNOTATION_PROJECT" \
+            --artifact-type "$VEX_ARTIFACT_TYPE" \
+            "$ARTIFACT:$TAG" \
+            "$VEX_FILE:application/json" \
+            --format json | jq -r .reference
+    )
+    cosign sign -y "$VEX_REF"
+fi
+
+# Attach provenance attestation to multi-arch index if available.
+PROVENANCE_FILE="cri-o.$ARCHIVE_ID.provenance.json"
+if [[ -e "$PROVENANCE_FILE" ]]; then
+    PROVENANCE_REF=$(
+        oras attach \
+            -a "$ANNOTATION_VERSION" \
+            -a "$ANNOTATION_COMMIT" \
+            -a "$ANNOTATION_BRANCH" \
+            -a "$ANNOTATION_PROJECT" \
+            --artifact-type "$PROVENANCE_ARTIFACT_TYPE" \
+            "$ARTIFACT:$TAG" \
+            "$PROVENANCE_FILE:application/json" \
+            --format json | jq -r .reference
+    )
+    cosign sign -y "$PROVENANCE_REF"
+fi

--- a/scripts/provenance
+++ b/scripts/provenance
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euox pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")"/vars
+
+# Determine the provenance file name.
+ARCHIVE_ID=$COMMIT
+if [[ "$PROJECT_TYPE" == "stable" ]]; then
+    ARCHIVE_ID="$REVISION"
+fi
+
+PROVENANCE_FILE="$ARCHIVE_PATH/cri-o.$ARCHIVE_ID.provenance.json"
+
+mkdir -p "$ARCHIVE_PATH"
+
+# Generate SLSA provenance attestation using tejolote.
+# The GitHub Actions run is referenced via the github:// scheme.
+# Use --wait=false because we are running inside the same workflow run,
+# waiting would deadlock. Point artifacts at the local build directory
+# since bundles have not been uploaded to GCS yet at this point.
+tejolote attest \
+    "github://cri-o/packaging/$GITHUB_RUN_ID" \
+    --artifacts "file://$ARCHIVE_PATH" \
+    --dependency "git+https://github.com/cri-o/cri-o@sha$COMMIT" \
+    --output "$PROVENANCE_FILE" \
+    --slsa 1.0 \
+    --wait=false
+
+echo "Provenance attestation generated at $PROVENANCE_FILE"

--- a/scripts/sign-artifacts
+++ b/scripts/sign-artifacts
@@ -23,3 +23,12 @@ if [[ -e "$VEX" ]]; then
         --output-signature "$VEX.sig" \
         --output-certificate "$VEX.cert"
 fi
+
+# Sign provenance attestation if available.
+PROVENANCE=$(echo build/bundle/*.provenance.json)
+if [[ -e "$PROVENANCE" ]]; then
+    cosign sign-blob -y "$PROVENANCE" \
+        --bundle "$PROVENANCE.bundle" \
+        --output-signature "$PROVENANCE.sig" \
+        --output-certificate "$PROVENANCE.cert"
+fi


### PR DESCRIPTION
/kind feature

#### What type of PR is this?

#### What this PR does / why we need it:
- Replace manual `bom` installation with `kubernetes-sigs/release-actions/setup-bom` (v0.4.2), which cosign-verifies the binary before use
- Add `tejolote`-based SLSA provenance generation to the bundles-publish pipeline using `setup-tejolote` from the same release-actions version
- Sign provenance attestation alongside existing VEX and SBOM artifacts
- Remove `bom` from `dependencies.yaml` (dependabot handles GitHub Action version bumps)

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:
The provenance attestation complements the existing SBOM and VEX artifacts by answering "how and where was this built." Uses `--wait=false` to avoid deadlock since tejolote runs inside the same workflow, and `file://` artifacts path since GCS upload happens after provenance generation.

#### Does this PR introduce a user-facing change?
```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added supply-chain provenance attestation generation for published bundles
  * Added cryptographic signing for provenance attestations

* **Chores**
  * Streamlined BOM/tool setup in CI workflows to use managed actions
  * Removed legacy BOM install steps and updated dependency mappings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->