### PR TITLE
packaging: bump runc to v1.4.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -139,7 +139,7 @@ dependencies:
         match: cri-tools
 
   - name: runc (latest)
-    version: v1.4.1
+    version: v1.4.2
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
         match: runc

--- a/templates/latest/cri-o/bundle/versions
+++ b/templates/latest/cri-o/bundle/versions
@@ -8,7 +8,7 @@ declare -A VERSIONS=(
     ["conmon-rs"]=v0.8.0
     ["cri-tools"]=v1.35.0
     ["crun"]=1.26
-    ["runc"]=v1.4.1
+    ["runc"]=v1.4.2
     ["crio-credential-provider"]=v0.1.2
 )
 export VERSIONS


### PR DESCRIPTION
#### What type of PR is this?
/kind dependency-change

#### What this PR does / why we need it:

Updates the packaged `runc` version to `v1.4.2` and keeps the dependency metadata in sync so newly generated bundles pull the fixed runtime release.

#### Which issue(s) this PR fixes:

Fixes #358

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated runc to v1.4.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->