### PR TITLE
Add v1.37 infrastructure and add-version automation

### DIFF
--- a/.github/workflows/add-version.yml
+++ b/.github/workflows/add-version.yml
@@ -1,0 +1,57 @@
+name: add-version
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >
+          The new version to add (e.g. v1.37).
+          Leave empty to auto-detect from the current README.
+        type: string
+jobs:
+  add-version:
+    if: github.ref == 'refs/heads/main' && github.repository == 'cri-o/packaging'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup osc
+        run: scripts/setup-osc
+        env:
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
+      - run: scripts/add-version "$VERSION"
+        env:
+          VERSION: ${{ inputs.version }}
+      - name: Detect version
+        id: version
+        run: |
+          VERSION="${VERSION_INPUT}"
+          if [ -z "$VERSION" ]; then
+            MINOR=$(grep -oP 'stable-v1\.\K[0-9]+(?=-yellow)' README.md)
+            if [ -z "$MINOR" ]; then
+              echo "::error::Failed to detect version from README"
+              exit 1
+            fi
+            VERSION="v1.$MINOR"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          VERSION_INPUT: ${{ inputs.version }}
+      - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          commit-message: Add ${{ steps.version.outputs.version }} to documentation
+          title: Add ${{ steps.version.outputs.version }} to documentation
+          body: |
+            /kind documentation
+
+            #### What this PR does / why we need it:
+            Add ${{ steps.version.outputs.version }} OBS project entries and badges to README.
+
+            ```release-note
+            None
+            ```
+          labels: kind/documentation
+          branch: add-${{ steps.version.outputs.version }}
+          delete-branch: true
+          signoff: true

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup osc
+        run: scripts/setup-osc
+        env:
+          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}
       - run: scripts/reconcile
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          OBS_PASSWORD: ${{ secrets.OBS_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ This project contains a bunch of other [subprojects](https://build.opensuse.org/
 > [CRI-O releases](https://github.com/cri-o/cri-o/releases) for the latest stable release.
 
 - [`isv:cri-o:stable`](https://build.opensuse.org/project/show/isv:cri-o:stable): Stable Packages (Umbrella)
+  - [`isv:cri-o:stable:v1.37`](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.37): `v1.37.z` tags (Stable)
+    - [`isv:cri-o:stable:v1.37:build`](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.37:build): `v1.37.z` tags (Builder)
   - [`isv:cri-o:stable:v1.36`](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.36): `v1.36.z` tags (Stable)
     - [`isv:cri-o:stable:v1.36:build`](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.36:build): `v1.36.z` tags (Builder)
   - [`isv:cri-o:stable:v1.35`](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.35): `v1.35.z` tags (Stable)
@@ -87,6 +89,8 @@ This project contains a bunch of other [subprojects](https://build.opensuse.org/
 - [`isv:cri-o:prerelease`](https://build.opensuse.org/project/show/isv:cri-o:prerelease): Prerelease Packages (Umbrella)
   - [`isv:cri-o:prerelease:main`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:main): [`main`](https://github.com/cri-o/cri-o/commits/main) branch (Prerelease)
     - [`isv:cri-o:prerelease:main:build`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:main:build): [`main`](https://github.com/cri-o/cri-o/commits/main) branch (Builder)
+  - [`isv:cri-o:prerelease:v1.37`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.37): [`release-1.37`](https://github.com/cri-o/cri-o/commits/release-1.37) branch (Prerelease)
+    - [`isv:cri-o:prerelease:v1.37:build`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.37:build): [`release-1.37`](https://github.com/cri-o/cri-o/commits/release-1.37) branch (Builder)
   - [`isv:cri-o:prerelease:v1.36`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.36): [`release-1.36`](https://github.com/cri-o/cri-o/commits/release-1.36) branch (Prerelease)
     - [`isv:cri-o:prerelease:v1.36:build`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.36:build): [`release-1.36`](https://github.com/cri-o/cri-o/commits/release-1.36) branch (Builder)
   - [`isv:cri-o:prerelease:v1.35`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.35): [`release-1.35`](https://github.com/cri-o/cri-o/commits/release-1.35) branch (Prerelease)
@@ -127,7 +131,8 @@ All packages are based on the static binary bundles provided by the CRI-O CI.
 
 #### Stable
 
-[![v1.36](https://img.shields.io/badge/stable-v1.36-yellow?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.36)
+[![v1.37](https://img.shields.io/badge/stable-v1.37-yellow?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.37)
+[![v1.36](https://img.shields.io/badge/stable-v1.36-brightgreen?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.36)
 [![v1.35](https://img.shields.io/badge/stable-v1.35-brightgreen?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.35)
 [![v1.34](https://img.shields.io/badge/stable-v1.34-brightgreen?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.34)
 [![v1.33](https://img.shields.io/badge/stable-v1.33-brightgreen?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:v1.33)
@@ -143,6 +148,7 @@ All packages are based on the static binary bundles provided by the CRI-O CI.
 #### Prerelease
 
 [![main](https://img.shields.io/badge/prerelease-main-blue?logo=git&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:main)
+[![release-1.37](https://img.shields.io/badge/prerelease-release--1.37-blue?logo=git&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.37)
 [![release-1.36](https://img.shields.io/badge/prerelease-release--1.36-blue?logo=git&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.36)
 [![release-1.35](https://img.shields.io/badge/prerelease-release--1.35-blue?logo=git&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.35)
 [![release-1.34](https://img.shields.io/badge/prerelease-release--1.34-blue?logo=git&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:v1.34)

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -31,6 +31,8 @@ dependencies:
     refPaths:
       - path: scripts/helpers
         match: OSC_VERSION
+      - path: scripts/setup-osc
+        match: OSC_VERSION
 
   - name: Fedora test image
     version: 42

--- a/scripts/add-version
+++ b/scripts/add-version
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")"/helpers
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+README="$GIT_ROOT/README.md"
+
+PROJECT_PREFIX=isv:cri-o
+
+infer_versions() {
+    PREV_MINOR=$(grep -oP 'stable-v1\.\K[0-9]+(?=-yellow)' "$README")
+    PREV_VERSION="v1.$PREV_MINOR"
+    NEW_VERSION="v1.$((PREV_MINOR + 1))"
+    echo "Previous version: $PREV_VERSION"
+    echo "New version: $NEW_VERSION"
+}
+
+create_obs_project() {
+    local src=$1 dst=$2
+    echo "Creating OBS project: $dst (from $src)"
+
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    osc meta prj "$src" >"$tmpfile"
+    sed -i "s|$src|$dst|g" "$tmpfile"
+    sed -i "s|${PREV_VERSION#v}|${NEW_VERSION#v}|g" "$tmpfile"
+    osc meta prj "$dst" -F "$tmpfile"
+    rm -f "$tmpfile"
+}
+
+create_obs_package() {
+    local src_project=$1 dst_project=$2 package=$3
+    echo "Creating OBS package: $dst_project/$package (from $src_project/$package)"
+
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    osc meta pkg "$src_project" "$package" >"$tmpfile"
+    sed -i "s|$src_project|$dst_project|g" "$tmpfile"
+    osc meta pkg "$dst_project" "$package" -F "$tmpfile"
+    rm -f "$tmpfile"
+}
+
+create_obs_projects() {
+    create_obs_project "$PROJECT_PREFIX:stable:$PREV_VERSION" "$PROJECT_PREFIX:stable:$NEW_VERSION"
+    create_obs_project "$PROJECT_PREFIX:stable:$PREV_VERSION:build" "$PROJECT_PREFIX:stable:$NEW_VERSION:build"
+    create_obs_project "$PROJECT_PREFIX:prerelease:$PREV_VERSION" "$PROJECT_PREFIX:prerelease:$NEW_VERSION"
+    create_obs_project "$PROJECT_PREFIX:prerelease:$PREV_VERSION:build" "$PROJECT_PREFIX:prerelease:$NEW_VERSION:build"
+
+    create_obs_package "$PROJECT_PREFIX:stable:$PREV_VERSION:build" "$PROJECT_PREFIX:stable:$NEW_VERSION:build" cri-o
+    create_obs_package "$PROJECT_PREFIX:prerelease:$PREV_VERSION:build" "$PROJECT_PREFIX:prerelease:$NEW_VERSION:build" cri-o
+}
+
+update_readme() {
+    echo "Updating README.md for $NEW_VERSION"
+
+    local new_minor=${NEW_VERSION#v1.}
+
+    # Add stable project entries after the umbrella line
+    sed -i "/^\- \[\`isv:cri-o:stable\`\]/a\\
+  - [\`isv:cri-o:stable:$NEW_VERSION\`](https://build.opensuse.org/project/show/isv:cri-o:stable:$NEW_VERSION): \`$NEW_VERSION.z\` tags (Stable)\\
+    - [\`isv:cri-o:stable:$NEW_VERSION:build\`](https://build.opensuse.org/project/show/isv:cri-o:stable:$NEW_VERSION:build): \`$NEW_VERSION.z\` tags (Builder)" "$README"
+
+    # Add prerelease project entries after the main:build line (match the linked version, not the plain text example)
+    sed -i "/isv:cri-o:prerelease:main:build.*branch (Builder)/a\\
+  - [\`isv:cri-o:prerelease:$NEW_VERSION\`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:$NEW_VERSION): [\`release-1.$new_minor\`](https://github.com/cri-o/cri-o/commits/release-1.$new_minor) branch (Prerelease)\\
+    - [\`isv:cri-o:prerelease:$NEW_VERSION:build\`](https://build.opensuse.org/project/show/isv:cri-o:prerelease:$NEW_VERSION:build): [\`release-1.$new_minor\`](https://github.com/cri-o/cri-o/commits/release-1.$new_minor) branch (Builder)" "$README"
+
+    # Change previous yellow stable badge to brightgreen
+    sed -i "s|stable-$PREV_VERSION-yellow|stable-$PREV_VERSION-brightgreen|" "$README"
+
+    # Add new yellow stable badge before the previous one
+    sed -i "/stable-$PREV_VERSION-brightgreen/i\\
+[![$NEW_VERSION](https://img.shields.io/badge/stable-$NEW_VERSION-yellow?logo=github)](https://build.opensuse.org/project/show/isv:cri-o:stable:$NEW_VERSION)" "$README"
+
+    # Add new prerelease badge after the main badge
+    sed -i "/prerelease-main-blue/a\\
+[![release-1.$new_minor](https://img.shields.io/badge/prerelease-release--1.$new_minor-blue?logo=git\&logoColor=white)](https://build.opensuse.org/project/show/isv:cri-o:prerelease:$NEW_VERSION)" "$README"
+
+    echo "README.md updated"
+}
+
+if [[ ${1:-} != "" ]]; then
+    PREV_VERSION=""
+    NEW_VERSION=$1
+    if [[ ! $NEW_VERSION =~ ^v ]]; then
+        NEW_VERSION="v$NEW_VERSION"
+    fi
+    # Derive the previous version from the new one
+    local_minor=${NEW_VERSION#v1.}
+    PREV_VERSION="v1.$((local_minor - 1))"
+    echo "Using provided version: $NEW_VERSION (previous: $PREV_VERSION)"
+else
+    infer_versions
+fi
+
+if grep -q "stable:$NEW_VERSION" "$README"; then
+    echo "Version $NEW_VERSION already exists in README"
+    exit 1
+fi
+
+if [[ ${SKIP_OBS:-} != "1" ]]; then
+    create_obs_projects
+fi
+
+update_readme

--- a/scripts/reconcile
+++ b/scripts/reconcile
@@ -3,21 +3,10 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 
-OBS_PASSWORD=${OBS_PASSWORD:-}
-
-setup_osc() {
-    printf "[general]\napiurl = https://api.opensuse.org\n[https://api.opensuse.org]\n" >~/.oscrc
-    echo user=cri-o-release-bot >>~/.oscrc
-    echo "pass=$OBS_PASSWORD" >>~/.oscrc
-}
-
 submit_workflow() {
     echo "Running GitHub OBS workflow for revision: $1"
     gh workflow run obs -F revision="$1"
 }
-
-install_osc
-setup_osc
 
 PACKAGES=$(osc se --package cri-o)
 PROJECT_PREFIX=isv:cri-o

--- a/scripts/setup-osc
+++ b/scripts/setup-osc
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OBS_PASSWORD=${OBS_PASSWORD:-}
+if [[ -z "$OBS_PASSWORD" ]]; then
+    echo "OBS_PASSWORD is not set" >&2
+    exit 1
+fi
+
+OSC_VERSION=1.25.0
+sudo apt update -y && sudo apt install -y python3-ruamel.yaml
+curl -sSfL --retry 5 --retry-delay 3 \
+    "https://github.com/openSUSE/osc/archive/refs/tags/$OSC_VERSION.tar.gz" -o- | tar xfz -
+pushd "osc-$OSC_VERSION"
+sudo ./setup.py build
+sudo ./setup.py install
+popd
+
+umask 077
+printf "[general]\napiurl = https://api.opensuse.org\n[https://api.opensuse.org]\nuser=cri-o-release-bot\npass=%s\n" "$OBS_PASSWORD" >~/.oscrc


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Add v1.37 OBS project entries (stable, prerelease, build subprojects, and packages) and README badges. Introduce `scripts/add-version` to automate future version additions with a corresponding `add-version` GitHub Actions workflow.

#### Which issue(s) this PR fixes:
Refers to https://github.com/cri-o/packaging/issues/347

#### Special notes for your reviewer:
The v1.37 OBS projects and packages have already been created and verified against the v1.36 metas.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual, triggerable workflow to add a new release version (optional version input) and open a documentation PR.
  * Automation to create new stable/prerelease entries and update release metadata and badges.

* **Refactor / Chores**
  * Reworked release tooling to use a shared, secure credential/setup helper.
  * Added a dedicated setup helper for OBS credentials; inline credential setup removed from reconciliation flow.

* **Documentation**
  * Added CRI-O v1.37 to stable/prerelease streams and updated badges and links.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/packaging/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->