### PR TITLE
Improve CI reliability: error handling, signature verification, reconciler dedup

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -183,6 +183,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - run: scripts/sign-artifacts
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
+      - run: scripts/verify-artifacts
+        if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
       - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
         with:

--- a/scripts/add-version
+++ b/scripts/add-version
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 

--- a/scripts/bundle/build
+++ b/scripts/bundle/build
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/../vars
 

--- a/scripts/github-job-wait
+++ b/scripts/github-job-wait
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-set -x
+set -euox pipefail
 
 retry_3() {
     for _ in 1 2 3; do

--- a/scripts/obs
+++ b/scripts/obs
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 

--- a/scripts/oci-artifacts
+++ b/scripts/oci-artifacts
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 

--- a/scripts/provenance
+++ b/scripts/provenance
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 

--- a/scripts/reconcile
+++ b/scripts/reconcile
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 
 submit_workflow() {
+    for STATUS in queued in_progress; do
+        if gh run list -w obs -s "$STATUS" --json displayTitle \
+            -q '.[].displayTitle' | grep -qxF "publish on OBS / $1"; then
+            echo "Skipping, workflow already $STATUS for revision: $1"
+            return
+        fi
+    done
     echo "Running GitHub OBS workflow for revision: $1"
     gh workflow run obs -F revision="$1"
 }

--- a/scripts/sign-artifacts
+++ b/scripts/sign-artifacts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")"/helpers
 
 for TARBALL in build/bundle/*.tar.gz; do
     cosign sign-blob -y "$TARBALL" \
@@ -15,20 +16,18 @@ for SBOM in build/bundle/*.tar.gz.spdx; do
         --output-certificate "$SBOM.cert"
 done
 
-# Sign VEX file if available (not every release branch publishes one).
-VEX=$(echo build/bundle/*.openvex.json)
-if [[ -e "$VEX" ]]; then
+for VEX in build/bundle/*.openvex.json; do
+    [[ -e "$VEX" ]] || continue
     cosign sign-blob -y "$VEX" \
         --bundle "$VEX.bundle" \
         --output-signature "$VEX.sig" \
         --output-certificate "$VEX.cert"
-fi
+done
 
-# Sign provenance attestation if available.
-PROVENANCE=$(echo build/bundle/*.provenance.json)
-if [[ -e "$PROVENANCE" ]]; then
+for PROVENANCE in build/bundle/*.provenance.json; do
+    [[ -e "$PROVENANCE" ]] || continue
     cosign sign-blob -y "$PROVENANCE" \
         --bundle "$PROVENANCE.bundle" \
         --output-signature "$PROVENANCE.sig" \
         --output-certificate "$PROVENANCE.cert"
-fi
+done

--- a/scripts/test-architectures
+++ b/scripts/test-architectures
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 

--- a/scripts/test-kubernetes
+++ b/scripts/test-kubernetes
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 

--- a/scripts/verify-artifacts
+++ b/scripts/verify-artifacts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")"/helpers
+
+IDENTITY="https://github.com/cri-o/packaging/.github/workflows/obs.yml@.*"
+ISSUER=https://token.actions.githubusercontent.com
+
+verify_blob() {
+    echo "Verifying $1"
+    cosign verify-blob "$1" \
+        --certificate-identity-regexp "$IDENTITY" \
+        --certificate-oidc-issuer "$ISSUER" \
+        --certificate-github-workflow-repository cri-o/packaging \
+        --bundle "$1.bundle"
+}
+
+for TARBALL in build/bundle/*.tar.gz; do
+    verify_blob "$TARBALL"
+done
+
+for SBOM in build/bundle/*.tar.gz.spdx; do
+    verify_blob "$SBOM"
+done
+
+for VEX in build/bundle/*.openvex.json; do
+    [[ -e "$VEX" ]] || continue
+    verify_blob "$VEX"
+done
+
+for PROVENANCE in build/bundle/*.provenance.json; do
+    [[ -e "$PROVENANCE" ]] || continue
+    verify_blob "$PROVENANCE"
+done

--- a/scripts/vex
+++ b/scripts/vex
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euox pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")"/vars
 


### PR DESCRIPTION
/kind ci

#### What this PR does / why we need it:
Standardizes error handling across shell scripts, adds cosign signature verification in CI, and prevents duplicate reconciler workflow triggers.

**Error handling:** Consolidates `set -euox pipefail` in `scripts/helpers` and removes redundant `set` lines from all scripts that source `helpers` or `vars`. Makes `scripts/sign-artifacts` source `helpers` for consistent tracing and shared functions. Scripts with code before their `source` line (`vars`, `bundle/test`) and intentionally standalone scripts (`setup-osc`, `tree-status`, `github-actions-setup`) keep their own `set` line.

**Signature verification:** Adds `scripts/verify-artifacts` to verify cosign signatures immediately after signing in the `bundles-publish` workflow job. This catches broken signing before artifacts are uploaded to GCS. Uses the same identity, issuer, and repository constraints as the `get` script.

**Reconciler deduplication:** Modifies `submit_workflow()` in `scripts/reconcile` to check for existing queued or in-progress `obs` workflow runs before triggering new ones, matching on the workflow display title. The existing `github-job-wait` mechanism in `obs.yml` remains as a safety net for same-commit deduplication.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

`setup-osc` intentionally omits `-x` to avoid leaking `OBS_PASSWORD` in trace output.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated verification of supply-chain artifacts with cryptographic signature validation and identity checks.

* **Improvements**
  * Prevents duplicate workflow submissions for the same revision, reducing redundant build jobs.

* **Chores**
  * Updated build system error handling and execution configurations across multiple build scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cri-o/packaging/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->