### PR TITLE
Pin VirtualBox Vagrant box URL to dated version

### DIFF
--- a/test/rpm/Vagrantfile
+++ b/test/rpm/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure("2") do |config|
   cpus = 4
 
   config.vm.provider :virtualbox do |v, override|
-    override.vm.box_url = "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-latest.x86_64.vagrant-virtualbox.box"
+    override.vm.box_url = "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-Vagrant-10-20260622.0.x86_64.vagrant-virtualbox.box"
     v.memory = memory
     v.cpus = cpus
   end


### PR DESCRIPTION
/kind bug

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `-latest` symlink for the CentOS Stream 10 VirtualBox Vagrant box does not exist on cloud.centos.org (only the libvirt variant has one). This causes the RPM Kubernetes CI test to fail. Pin to the most recent available dated build (20260622.0) instead.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CentOS Stream 10 VirtualBox test VM to use a specific box image, improving consistency of the test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->