### PR TITLE
Bump conmon-rs to v1.0.1 for CRI-O v1.37+

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -128,8 +128,15 @@ dependencies:
       - path: templates/latest/cri-o/bundle/versions
         match: conmon
 
-  - name: conmon-rs (latest)
+  # TODO: remove once CRI-O v1.36 goes EOL
+  - name: conmon-rs (CRI-O <= v1.36)
     version: v0.8.0
+    refPaths:
+      - path: templates/latest/cri-o/bundle/versions
+        match: conmon-rs
+
+  - name: conmon-rs (CRI-O >= v1.37)
+    version: v1.0.1
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
         match: conmon-rs

--- a/templates/latest/cri-o/bundle/versions
+++ b/templates/latest/cri-o/bundle/versions
@@ -11,4 +11,13 @@ declare -A VERSIONS=(
     ["runc"]=v1.4.2
     ["crio-credential-provider"]=v0.1.2
 )
+# TODO: remove the conditional override and set the default to v1.0.1 once
+# CRI-O v1.36 goes EOL.
+# conmon-rs v1.0.0+ requires CRI-O v1.37+
+if [[ "${PROJECT_VERSION:-}" == "main" ]] ||
+    { [[ "${PROJECT_VERSION:-}" =~ ^v([0-9]+)\.([0-9]+)$ ]] &&
+        [[ ${BASH_REMATCH[1]} -ge 2 || (${BASH_REMATCH[1]} -eq 1 && ${BASH_REMATCH[2]} -ge 37) ]]; }; then
+    VERSIONS["conmon-rs"]=v1.0.1
+fi
+
 export VERSIONS


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Bumps conmon-rs to v1.0.1 for CRI-O v1.37+ and main, while keeping v0.8.0 for older releases (v1.34-v1.36). conmon-rs v1.0.0+ removed backward-compatible Cap'n Proto fields, so it is only compatible with CRI-O v1.37+.

The version override is conditional on `$PROJECT_VERSION` which is set by `scripts/vars` before the versions file is sourced.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Release notes: https://github.com/containers/conmon-rs/releases/tag/v1.0.1

#### Does this PR introduce a user-facing change?

```release-note
None
```