### PR TITLE
Fix conmon-rs cosign verification in bundle build for <= v1.36

### DIFF
--- a/scripts/bundle/build
+++ b/scripts/bundle/build
@@ -98,7 +98,7 @@ curl_to "$TMP_BIN/conmon" \
 chmod +x "$TMP_BIN/conmon"
 
 # conmon-rs
-curl_retry https://raw.githubusercontent.com/containers/conmon-rs/main/scripts/get |
+curl_retry "https://raw.githubusercontent.com/containers/conmon-rs/${VERSIONS["conmon-rs"]}/scripts/get" |
     bash -s -- -n -a "$ARCH" -l "${VERSIONS["conmon-rs"]}" -o "$TMP_BIN/conmonrs"
 
 # runc


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses the conmon-rs `get` script from the matching release tag instead of `main`. The `main` branch script hardcodes the cosign certificate identity to `refs/heads/main`, which fails for v0.8.0 binaries that were signed from their tag ref (`refs/tags/v0.8.0`).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to retrieve the `conmon-rs` script from the configured version instead of the moving main branch, improving build consistency and repeatability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->