### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -239,10 +239,10 @@ jobs:
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
       - uses: kubernetes-sigs/release-actions/setup-bom@b5b8280a60e6e20607f77068011269b982c60971 # v0.4.5
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
-      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # main (ORAS 1.3.1 support)
+      - uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
         with:
-          version: 1.3.1
+          version: 1.3.3
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         if: ${{ inputs.skip-bundles == false && github.event_name != 'pull_request' }}
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CONTAINER_RUNTIME ?= podman
 
-ZEITGEIST_VERSION = v0.5.4
-SHFMT_VERSION := v3.13.0
+ZEITGEIST_VERSION = v0.8.0
+SHFMT_VERSION := v3.13.1
 SHELLCHECK_VERSION := v0.11.0
 MDTOC_VERSION := v1.4.0
 
@@ -23,7 +23,7 @@ clean:
 	rm -rf $(BUILD_DIR)
 
 $(ZEITGEIST): $(BUILD_DIR)
-	$(call curl_to,https://storage.googleapis.com/k8s-artifacts-sig-release/kubernetes-sigs/zeitgeist/$(ZEITGEIST_VERSION)/zeitgeist-amd64-linux,$(ZEITGEIST))
+	$(call curl_to,https://github.com/kubernetes-sigs/zeitgeist/releases/download/$(ZEITGEIST_VERSION)/zeitgeist-amd64-linux,$(ZEITGEIST))
 	chmod +x $(ZEITGEIST)
 
 $(SHFMT): $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ curl https://raw.githubusercontent.com/cri-o/packaging/main/get | bash -s -- -a 
 It is also possible to select a specific git SHA or tag by:
 
 ```shell
-curl https://raw.githubusercontent.com/cri-o/packaging/main/get | bash -s -- -t v1.36.0
+curl https://raw.githubusercontent.com/cri-o/packaging/main/get | bash -s -- -t v1.36.4
 ```
 
 The above script resolves to the download URL of the static binary bundle

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -4,35 +4,33 @@ dependencies:
     version: v1.36
     refPaths:
       - path: README.md
-        match: CRIO_VERSION
-      - path: README.md
-        match: bash -s -- -t
+        match: CRIO_VERSION=
 
   - name: zeitgeist
-    version: v0.5.4
+    version: v0.8.0
     refPaths:
       - path: Makefile
-        match: ZEITGEIST_VERSION
+        match: ZEITGEIST_VERSION =
 
   - name: Kubernetes test version
     version: v1.36
     refPaths:
       - path: test/scripts/versions.sh
-        match: KUBERNETES_VERSION
+        match: KUBERNETES_VERSION=
       - path: test/deb/lima.yaml
-        match: KUBERNETES_VERSION
+        match: KUBERNETES_VERSION=
       - path: test/rpm/lima.yaml
-        match: KUBERNETES_VERSION
+        match: KUBERNETES_VERSION=
       - path: README.md
-        match: KUBERNETES_VERSION
+        match: KUBERNETES_VERSION=
 
   - name: OSC
-    version: 1.25.0
+    version: 1.27.3
     refPaths:
       - path: scripts/helpers
-        match: OSC_VERSION
+        match: OSC_VERSION=
       - path: scripts/setup-osc
-        match: OSC_VERSION
+        match: OSC_VERSION=
 
   - name: Fedora test image
     version: 42
@@ -78,43 +76,43 @@ dependencies:
     version: 7.2.0-1
     refPaths:
       - path: scripts/test-architectures
-        match: QEMUVERSION
+        match: QEMUVERSION=
 
   - name: shellcheck
     version: v0.11.0
     refPaths:
       - path: Makefile
-        match: SHELLCHECK_VERSION
+        match: SHELLCHECK_VERSION :=
 
   - name: shellfmt
-    version: v3.13.0
+    version: v3.13.1
     refPaths:
       - path: Makefile
-        match: SHFMT_VERSION
+        match: SHFMT_VERSION :=
 
   - name: mdtoc
     version: v1.4.0
     refPaths:
       - path: Makefile
-        match: MDTOC_VERSION
+        match: MDTOC_VERSION :=
 
   - name: krel
-    version: v0.20.1
+    version: v0.21.1
     refPaths:
       - path: scripts/helpers
-        match: KREL_VERSION
+        match: KREL_VERSION=
 
   - name: oras
-    version: 1.3.1
+    version: 1.3.3
     refPaths:
       - path: .github/workflows/obs.yml
-        match: version
+        match: "version: 1."
 
   - name: debian base
     version: bookworm-v1.0.7
     refPaths:
       - path: test/testdata/container.json
-        match: image
+        match: debian-base
 
   - name: cni-plugins (latest)
     version: v1.9.1
@@ -126,20 +124,20 @@ dependencies:
     version: v2.2.1
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
-        match: conmon
+        match: '"conmon"'
 
   # TODO: remove once CRI-O v1.36 goes EOL
   - name: conmon-rs (CRI-O <= v1.36)
     version: v0.8.0
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
-        match: conmon-rs
+        match: '"conmon-rs"]=v0'
 
   - name: conmon-rs (CRI-O >= v1.37)
     version: v1.0.1
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
-        match: conmon-rs
+        match: '"conmon-rs"]=v1'
 
   - name: cri-tools (latest)
     version: v1.36.0
@@ -148,13 +146,13 @@ dependencies:
         match: cri-tools
 
   - name: runc (latest)
-    version: v1.4.2
+    version: v1.5.1
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
         match: runc
 
   - name: crun (latest)
-    version: 1.26
+    version: 1.29.1
     refPaths:
       - path: templates/latest/cri-o/bundle/versions
         match: crun

--- a/scripts/helpers
+++ b/scripts/helpers
@@ -17,7 +17,7 @@ curl_retry() {
 }
 
 install_osc() {
-    OSC_VERSION=1.25.0
+    OSC_VERSION=1.27.3
     # Because of https://github.com/openSUSE/osc/issues/1819 , ruamel.yaml should be installed separately
     sudo apt update -y && sudo apt install -y python3-ruamel.yaml
     curl_retry https://github.com/openSUSE/osc/archive/refs/tags/$OSC_VERSION.tar.gz -o- | tar xfz -
@@ -28,7 +28,7 @@ install_osc() {
 }
 
 install_krel() {
-    KREL_VERSION=v0.20.1
+    KREL_VERSION=v0.21.1
     install_binary https://github.com/kubernetes/release/releases/download/$KREL_VERSION/krel-amd64-linux krel
 }
 

--- a/scripts/setup-osc
+++ b/scripts/setup-osc
@@ -7,7 +7,7 @@ if [[ -z "$OBS_PASSWORD" ]]; then
     exit 1
 fi
 
-OSC_VERSION=1.25.0
+OSC_VERSION=1.27.3
 sudo apt update -y && sudo apt install -y python3-ruamel.yaml
 curl -sSfL --retry 5 --retry-delay 3 \
     "https://github.com/openSUSE/osc/archive/refs/tags/$OSC_VERSION.tar.gz" -o- | tar xfz -

--- a/templates/latest/cri-o/bundle/versions
+++ b/templates/latest/cri-o/bundle/versions
@@ -7,8 +7,8 @@ declare -A VERSIONS=(
     ["conmon"]=v2.2.1
     ["conmon-rs"]=v0.8.0
     ["cri-tools"]=v1.36.0
-    ["crun"]=1.26
-    ["runc"]=v1.4.2
+    ["crun"]=1.29.1
+    ["runc"]=v1.5.1
     ["crio-credential-provider"]=v0.1.2
 )
 # TODO: remove the conditional override and set the default to v1.0.1 once


### PR DESCRIPTION
/kind dependency-change

#### What this PR does / why we need it:
Bumps all outdated dependencies to their latest versions:
- zeitgeist: v0.5.4 -> v0.8.0
- osc: 1.25.0 -> 1.27.3
- shfmt: v3.13.0 -> v3.13.1
- krel: v0.20.1 -> v0.21.1
- oras: 1.3.1 -> 1.3.3
- runc: v1.4.2 -> v1.5.1
- crun: 1.26 -> 1.29.1

Also updates the zeitgeist download URL from GCS to GitHub Releases, since versions after v0.5.4 are no longer published to GCS. Pins setup-oras to the v2.0.1 tag. Fixes dependencies.yaml match patterns to be more specific, avoiding false positives from shell variable references and overlapping names in zeitgeist v0.8.0 validation. Updates the CRI-O tag example in README.md to v1.36.4.

#### Which issue(s) this PR fixes:
None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
None
```