### PR TITLE
Bump Kubernetes version to v1.37

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ All packages are based on the static binary bundles provided by the CRI-O CI.
 #### Define the Kubernetes version and used CRI-O stream
 
 ```bash
-KUBERNETES_VERSION=v1.36
+KUBERNETES_VERSION=v1.37
 CRIO_VERSION=v1.36
 ```
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -13,7 +13,7 @@ dependencies:
         match: ZEITGEIST_VERSION =
 
   - name: Kubernetes test version
-    version: v1.36
+    version: v1.37
     refPaths:
       - path: test/scripts/versions.sh
         match: KUBERNETES_VERSION=

--- a/test/deb/lima.yaml
+++ b/test/deb/lima.yaml
@@ -22,7 +22,7 @@ provision:
       test -e /etc/kubernetes/admin.conf && exit 0
 
         # Package configs
-        KUBERNETES_VERSION=v1.36
+        KUBERNETES_VERSION=v1.37
         PROJECT_PATH=prerelease:/main
 
         curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg

--- a/test/rpm/lima.yaml
+++ b/test/rpm/lima.yaml
@@ -24,7 +24,7 @@ provision:
       test -e /etc/kubernetes/admin.conf && exit 0
 
         # Package configs
-        KUBERNETES_VERSION=v1.36
+        KUBERNETES_VERSION=v1.37
         PROJECT_PATH=prerelease:/main
 
         cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo

--- a/test/scripts/versions.sh
+++ b/test/scripts/versions.sh
@@ -3,6 +3,6 @@
 # shellcheck disable=SC2034 # variables are used in sourcing scripts
 
 # Package configs
-KUBERNETES_VERSION=v1.36
+KUBERNETES_VERSION=v1.37
 # allows to be set externally e.g. from a Dockerfile
 PROJECT_PATH=${PROJECT_PATH:-prerelease:/main}


### PR DESCRIPTION
#### What type of PR is this?

/kind dependency-change

#### What this PR does / why we need it:

Bumps the Kubernetes test version and CRI-O version references from v1.36 to v1.37 across all relevant files.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

cri-tools stays at v1.36.0 since v1.37.0 is not released yet.

#### Does this PR introduce a user-facing change?

```release-note
None
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported Kubernetes and CRI-O versions to v1.37.
  - Updated installation examples and test environments to use Kubernetes v1.37.
  - Refreshed documented version references for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->